### PR TITLE
feat: 280자 텍스트 포스트 작성 및 단일 포스트 조회

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -4,6 +4,17 @@ import (
 	"github.com/kitae0522/twitter-clone-claude/backend/internal/model"
 )
 
+type CreatePostRequest struct {
+	Content    string `json:"content"`
+	Visibility string `json:"visibility"`
+}
+
+type PostAuthor struct {
+	Username        string `json:"username"`
+	DisplayName     string `json:"displayName"`
+	ProfileImageURL string `json:"profileImageUrl"`
+}
+
 type PostResponse struct {
 	ID         string `json:"id"`
 	AuthorID   string `json:"authorId"`
@@ -13,13 +24,39 @@ type PostResponse struct {
 	UpdatedAt  string `json:"updatedAt"`
 }
 
+type PostDetailResponse struct {
+	ID         string     `json:"id"`
+	AuthorID   string     `json:"authorId"`
+	Content    string     `json:"content"`
+	Visibility string     `json:"visibility"`
+	Author     PostAuthor `json:"author"`
+	CreatedAt  string     `json:"createdAt"`
+	UpdatedAt  string     `json:"updatedAt"`
+}
+
 func ToPostResponse(p model.Post) PostResponse {
 	return PostResponse{
-		ID:         p.ID,
-		AuthorID:   p.AuthorID,
+		ID:         p.ID.String(),
+		AuthorID:   p.AuthorID.String(),
 		Content:    p.Content,
 		Visibility: string(p.Visibility),
 		CreatedAt:  p.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt:  p.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+	}
+}
+
+func ToPostDetailResponse(p model.PostWithAuthor) PostDetailResponse {
+	return PostDetailResponse{
+		ID:         p.ID.String(),
+		AuthorID:   p.AuthorID.String(),
+		Content:    p.Content,
+		Visibility: string(p.Visibility),
+		Author: PostAuthor{
+			Username:        p.AuthorUsername,
+			DisplayName:     p.AuthorDisplayName,
+			ProfileImageURL: p.AuthorProfileImageURL,
+		},
+		CreatedAt: p.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		UpdatedAt: p.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 	}
 }

--- a/backend/internal/handler/post_handler.go
+++ b/backend/internal/handler/post_handler.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
 	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
 	"github.com/kitae0522/twitter-clone-claude/backend/internal/service"
 )
@@ -14,25 +16,59 @@ func NewPostHandler(ps service.PostService) *PostHandler {
 	return &PostHandler{postService: ps}
 }
 
-func (h *PostHandler) GetPosts(c *fiber.Ctx) error {
-	posts, err := h.postService.GetPosts()
-	if err != nil {
-		errMsg := err.Error()
-		return c.Status(fiber.StatusInternalServerError).JSON(dto.APIResponse{
-			Success: false,
-			Data:    nil,
-			Error:   &errMsg,
-		})
+func (h *PostHandler) CreatePost(c *fiber.Ctx) error {
+	userIDStr, ok := c.Locals("userID").(string)
+	if !ok {
+		return respondError(c, apperror.Unauthorized("not authenticated"))
 	}
 
-	responses := make([]dto.PostResponse, len(posts))
-	for i, p := range posts {
-		responses[i] = dto.ToPostResponse(p)
+	authorID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return respondError(c, apperror.Unauthorized("invalid user ID"))
+	}
+
+	var req dto.CreatePostRequest
+	if err := c.BodyParser(&req); err != nil {
+		return respondError(c, apperror.BadRequest("invalid request body"))
+	}
+
+	resp, err := h.postService.CreatePost(c.Context(), authorID, req)
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(dto.APIResponse{
+		Success: true,
+		Data:    resp,
+	})
+}
+
+func (h *PostHandler) GetPostByID(c *fiber.Ctx) error {
+	idStr := c.Params("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		return respondError(c, apperror.BadRequest("invalid post ID"))
+	}
+
+	resp, err := h.postService.GetPostByID(c.Context(), id)
+	if err != nil {
+		return respondError(c, err)
 	}
 
 	return c.JSON(dto.APIResponse{
 		Success: true,
-		Data:    responses,
-		Error:   nil,
+		Data:    resp,
+	})
+}
+
+func (h *PostHandler) GetPosts(c *fiber.Ctx) error {
+	posts, err := h.postService.GetPosts(c.Context())
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    posts,
 	})
 }

--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -1,6 +1,10 @@
 package model
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 type Visibility string
 
@@ -11,10 +15,17 @@ const (
 )
 
 type Post struct {
-	ID         string
-	AuthorID   string
+	ID         uuid.UUID
+	AuthorID   uuid.UUID
 	Content    string
 	Visibility Visibility
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
+}
+
+type PostWithAuthor struct {
+	Post
+	AuthorUsername        string
+	AuthorDisplayName    string
+	AuthorProfileImageURL string
 }

--- a/backend/internal/repository/post_repository.go
+++ b/backend/internal/repository/post_repository.go
@@ -1,0 +1,86 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/model"
+)
+
+type PostRepository interface {
+	Create(ctx context.Context, post *model.Post) error
+	FindByID(ctx context.Context, id uuid.UUID) (*model.PostWithAuthor, error)
+	FindAll(ctx context.Context, limit, offset int) ([]model.PostWithAuthor, error)
+}
+
+type postRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewPostRepository(pool *pgxpool.Pool) PostRepository {
+	return &postRepository{pool: pool}
+}
+
+func (r *postRepository) Create(ctx context.Context, post *model.Post) error {
+	query := `
+		INSERT INTO posts (author_id, content, visibility)
+		VALUES ($1, $2, $3)
+		RETURNING id, created_at, updated_at`
+
+	return r.pool.QueryRow(ctx, query,
+		post.AuthorID, post.Content, string(post.Visibility),
+	).Scan(&post.ID, &post.CreatedAt, &post.UpdatedAt)
+}
+
+func (r *postRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.PostWithAuthor, error) {
+	p := &model.PostWithAuthor{}
+	query := `
+		SELECT p.id, p.author_id, p.content, p.visibility, p.created_at, p.updated_at,
+		       u.username, u.display_name, u.profile_image_url
+		FROM posts p
+		JOIN users u ON p.author_id = u.id
+		WHERE p.id = $1`
+
+	var visibility string
+	err := r.pool.QueryRow(ctx, query, id).Scan(
+		&p.ID, &p.AuthorID, &p.Content, &visibility, &p.CreatedAt, &p.UpdatedAt,
+		&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
+	)
+	if err != nil {
+		return nil, err
+	}
+	p.Visibility = model.Visibility(visibility)
+	return p, nil
+}
+
+func (r *postRepository) FindAll(ctx context.Context, limit, offset int) ([]model.PostWithAuthor, error) {
+	query := `
+		SELECT p.id, p.author_id, p.content, p.visibility, p.created_at, p.updated_at,
+		       u.username, u.display_name, u.profile_image_url
+		FROM posts p
+		JOIN users u ON p.author_id = u.id
+		ORDER BY p.created_at DESC
+		LIMIT $1 OFFSET $2`
+
+	rows, err := r.pool.Query(ctx, query, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var posts []model.PostWithAuthor
+	for rows.Next() {
+		var p model.PostWithAuthor
+		var visibility string
+		if err := rows.Scan(
+			&p.ID, &p.AuthorID, &p.Content, &visibility, &p.CreatedAt, &p.UpdatedAt,
+			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
+		); err != nil {
+			return nil, err
+		}
+		p.Visibility = model.Visibility(visibility)
+		posts = append(posts, p)
+	}
+	return posts, rows.Err()
+}

--- a/backend/internal/service/post_service.go
+++ b/backend/internal/service/post_service.go
@@ -1,50 +1,91 @@
 package service
 
 import (
-	"time"
+	"context"
+	"unicode/utf8"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
 	"github.com/kitae0522/twitter-clone-claude/backend/internal/model"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/repository"
 )
 
 type PostService interface {
-	GetPosts() ([]model.Post, error)
+	CreatePost(ctx context.Context, authorID uuid.UUID, req dto.CreatePostRequest) (*dto.PostDetailResponse, error)
+	GetPostByID(ctx context.Context, id uuid.UUID) (*dto.PostDetailResponse, error)
+	GetPosts(ctx context.Context) ([]dto.PostDetailResponse, error)
 }
 
-type postService struct{}
-
-func NewPostService() PostService {
-	return &postService{}
+type postService struct {
+	postRepo repository.PostRepository
 }
 
-func (s *postService) GetPosts() ([]model.Post, error) {
-	now := time.Now()
+func NewPostService(postRepo repository.PostRepository) PostService {
+	return &postService{postRepo: postRepo}
+}
 
-	posts := []model.Post{
-		{
-			ID:         "550e8400-e29b-41d4-a716-446655440001",
-			AuthorID:   "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-			Content:    "Hello, world! This is my first public post.",
-			Visibility: model.VisibilityPublic,
-			CreatedAt:  now.Add(-2 * time.Hour),
-			UpdatedAt:  now.Add(-2 * time.Hour),
-		},
-		{
-			ID:         "550e8400-e29b-41d4-a716-446655440002",
-			AuthorID:   "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-			Content:    "Only my friends can see this post!",
-			Visibility: model.VisibilityFriends,
-			CreatedAt:  now.Add(-1 * time.Hour),
-			UpdatedAt:  now.Add(-1 * time.Hour),
-		},
-		{
-			ID:         "550e8400-e29b-41d4-a716-446655440003",
-			AuthorID:   "c3d4e5f6-a7b8-9012-cdef-123456789012",
-			Content:    "This is a private note to myself.",
-			Visibility: model.VisibilityPrivate,
-			CreatedAt:  now.Add(-30 * time.Minute),
-			UpdatedAt:  now.Add(-30 * time.Minute),
-		},
+func (s *postService) CreatePost(ctx context.Context, authorID uuid.UUID, req dto.CreatePostRequest) (*dto.PostDetailResponse, error) {
+	content := req.Content
+	if utf8.RuneCountInString(content) == 0 {
+		return nil, apperror.BadRequest("content must not be empty")
+	}
+	if utf8.RuneCountInString(content) > 280 {
+		return nil, apperror.BadRequest("content must not exceed 280 characters")
 	}
 
-	return posts, nil
+	visibility := model.VisibilityPublic
+	if req.Visibility != "" {
+		switch model.Visibility(req.Visibility) {
+		case model.VisibilityPublic, model.VisibilityFriends, model.VisibilityPrivate:
+			visibility = model.Visibility(req.Visibility)
+		default:
+			return nil, apperror.BadRequest("invalid visibility: %s", req.Visibility)
+		}
+	}
+
+	post := &model.Post{
+		AuthorID:   authorID,
+		Content:    content,
+		Visibility: visibility,
+	}
+
+	if err := s.postRepo.Create(ctx, post); err != nil {
+		return nil, apperror.Internal("failed to create post")
+	}
+
+	result, err := s.postRepo.FindByID(ctx, post.ID)
+	if err != nil {
+		return nil, apperror.Internal("failed to retrieve created post")
+	}
+
+	resp := dto.ToPostDetailResponse(*result)
+	return &resp, nil
+}
+
+func (s *postService) GetPostByID(ctx context.Context, id uuid.UUID) (*dto.PostDetailResponse, error) {
+	result, err := s.postRepo.FindByID(ctx, id)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, apperror.NotFound("post not found")
+		}
+		return nil, apperror.Internal("failed to retrieve post")
+	}
+
+	resp := dto.ToPostDetailResponse(*result)
+	return &resp, nil
+}
+
+func (s *postService) GetPosts(ctx context.Context) ([]dto.PostDetailResponse, error) {
+	posts, err := s.postRepo.FindAll(ctx, 50, 0)
+	if err != nil {
+		return nil, apperror.Internal("failed to retrieve posts")
+	}
+
+	responses := make([]dto.PostDetailResponse, len(posts))
+	for i, p := range posts {
+		responses[i] = dto.ToPostDetailResponse(p)
+	}
+	return responses, nil
 }

--- a/backend/internal/service/post_service_test.go
+++ b/backend/internal/service/post_service_test.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/model"
+)
+
+type mockPostRepo struct {
+	posts map[uuid.UUID]*model.PostWithAuthor
+}
+
+func newMockPostRepo() *mockPostRepo {
+	return &mockPostRepo{
+		posts: make(map[uuid.UUID]*model.PostWithAuthor),
+	}
+}
+
+func (m *mockPostRepo) Create(_ context.Context, post *model.Post) error {
+	post.ID = uuid.New()
+	m.posts[post.ID] = &model.PostWithAuthor{
+		Post:                  *post,
+		AuthorUsername:        "testuser",
+		AuthorDisplayName:     "Test User",
+		AuthorProfileImageURL: "",
+	}
+	return nil
+}
+
+func (m *mockPostRepo) FindByID(_ context.Context, id uuid.UUID) (*model.PostWithAuthor, error) {
+	if p, ok := m.posts[id]; ok {
+		return p, nil
+	}
+	return nil, pgx.ErrNoRows
+}
+
+func (m *mockPostRepo) FindAll(_ context.Context, _, _ int) ([]model.PostWithAuthor, error) {
+	var posts []model.PostWithAuthor
+	for _, p := range m.posts {
+		posts = append(posts, *p)
+	}
+	return posts, nil
+}
+
+func TestCreatePost_Success(t *testing.T) {
+	repo := newMockPostRepo()
+	svc := NewPostService(repo)
+
+	resp, err := svc.CreatePost(context.Background(), uuid.New(), dto.CreatePostRequest{
+		Content:    "Hello, world!",
+		Visibility: "public",
+	})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Content != "Hello, world!" {
+		t.Errorf("expected content 'Hello, world!', got %s", resp.Content)
+	}
+	if resp.Author.Username != "testuser" {
+		t.Errorf("expected author username 'testuser', got %s", resp.Author.Username)
+	}
+}
+
+func TestCreatePost_EmptyContent(t *testing.T) {
+	repo := newMockPostRepo()
+	svc := NewPostService(repo)
+
+	_, err := svc.CreatePost(context.Background(), uuid.New(), dto.CreatePostRequest{
+		Content: "",
+	})
+
+	if err == nil {
+		t.Fatal("expected error for empty content")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != 400 {
+		t.Errorf("expected 400, got %d", appErr.Code)
+	}
+}
+
+func TestCreatePost_ExceedsMaxLength(t *testing.T) {
+	repo := newMockPostRepo()
+	svc := NewPostService(repo)
+
+	longContent := strings.Repeat("a", 281)
+	_, err := svc.CreatePost(context.Background(), uuid.New(), dto.CreatePostRequest{
+		Content: longContent,
+	})
+
+	if err == nil {
+		t.Fatal("expected error for content exceeding 280 characters")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != 400 {
+		t.Errorf("expected 400, got %d", appErr.Code)
+	}
+}
+
+func TestGetPostByID_Success(t *testing.T) {
+	repo := newMockPostRepo()
+	svc := NewPostService(repo)
+
+	created, _ := svc.CreatePost(context.Background(), uuid.New(), dto.CreatePostRequest{
+		Content: "Test post",
+	})
+
+	postID, _ := uuid.Parse(created.ID)
+	resp, err := svc.GetPostByID(context.Background(), postID)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Content != "Test post" {
+		t.Errorf("expected content 'Test post', got %s", resp.Content)
+	}
+}
+
+func TestGetPostByID_NotFound(t *testing.T) {
+	repo := newMockPostRepo()
+	svc := NewPostService(repo)
+
+	_, err := svc.GetPostByID(context.Background(), uuid.New())
+	if err == nil {
+		t.Fatal("expected error for nonexistent post")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != 404 {
+		t.Errorf("expected 404, got %d", appErr.Code)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -31,7 +31,8 @@ func main() {
 		return c.JSON(fiber.Map{"status": "ok"})
 	})
 
-	postService := service.NewPostService()
+	postRepo := repository.NewPostRepository(pool)
+	postService := service.NewPostService(postRepo)
 	postHandler := handler.NewPostHandler(postService)
 
 	userRepo := repository.NewUserRepository(pool)
@@ -42,7 +43,10 @@ func main() {
 	userHandler := handler.NewUserHandler(userService)
 
 	api := app.Group("/api")
-	api.Get("/posts", postHandler.GetPosts)
+	posts := api.Group("/posts")
+	posts.Get("/", postHandler.GetPosts)
+	posts.Post("/", middleware.AuthRequired(cfg.JWTSecret), postHandler.CreatePost)
+	posts.Get("/:id", postHandler.GetPostByID)
 
 	auth := api.Group("/auth")
 	auth.Post("/register", authHandler.Register)

--- a/backend/migrations/003_create_posts.down.sql
+++ b/backend/migrations/003_create_posts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS posts;

--- a/backend/migrations/003_create_posts.up.sql
+++ b/backend/migrations/003_create_posts.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE posts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    content VARCHAR(280) NOT NULL,
+    visibility VARCHAR(20) NOT NULL DEFAULT 'public',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_posts_author_id ON posts(author_id);
+CREATE INDEX idx_posts_created_at ON posts(created_at DESC);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import HomePage from '@/pages/HomePage'
 import LoginPage from '@/pages/LoginPage'
 import RegisterPage from '@/pages/RegisterPage'
 import ProfilePage from '@/pages/ProfilePage'
+import PostDetailPage from '@/pages/PostDetailPage'
 import OnboardingPage from '@/pages/OnboardingPage'
 import './App.css'
 
@@ -40,6 +41,14 @@ function App() {
                 <GuestRoute>
                   <RegisterPage />
                 </GuestRoute>
+              }
+            />
+            <Route
+              path="/post/:id"
+              element={
+                <ProtectedRoute>
+                  <PostDetailPage />
+                </ProtectedRoute>
               }
             />
             <Route

--- a/frontend/src/components/ComposeForm.module.css
+++ b/frontend/src/components/ComposeForm.module.css
@@ -1,0 +1,63 @@
+.form {
+  padding: 16px;
+  border-bottom: 1px solid #2f3336;
+}
+
+.textarea {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: #e7e9ea;
+  font-size: 18px;
+  font-family: inherit;
+  resize: none;
+  outline: none;
+  padding: 8px 0;
+}
+
+.textarea::placeholder {
+  color: #71767b;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  padding-top: 8px;
+  border-top: 1px solid #2f3336;
+}
+
+.counter {
+  font-size: 14px;
+  color: #71767b;
+}
+
+.warn {
+  color: #ffd600;
+}
+
+.over {
+  color: #f4212e;
+}
+
+.button {
+  padding: 8px 20px;
+  border: none;
+  border-radius: 9999px;
+  background: #1d9bf0;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.button:hover:not(:disabled) {
+  background: #1a8cd8;
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/ComposeForm.tsx
+++ b/frontend/src/components/ComposeForm.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { useCreatePost } from '@/hooks/usePosts'
+import styles from './ComposeForm.module.css'
+
+const MAX_LENGTH = 280
+
+export default function ComposeForm() {
+  const [content, setContent] = useState('')
+  const { mutate, isPending } = useCreatePost()
+
+  const remaining = MAX_LENGTH - [...content].length
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (remaining < 0 || content.trim().length === 0 || isPending) return
+
+    mutate(
+      { content, visibility: 'public' },
+      { onSuccess: () => setContent('') },
+    )
+  }
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      <textarea
+        className={styles.textarea}
+        placeholder="What is happening?!"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        maxLength={300}
+        rows={3}
+      />
+      <div className={styles.footer}>
+        <span
+          className={`${styles.counter} ${remaining < 0 ? styles.over : remaining <= 20 ? styles.warn : ''}`}
+        >
+          {remaining}
+        </span>
+        <button
+          type="submit"
+          className={styles.button}
+          disabled={remaining < 0 || content.trim().length === 0 || isPending}
+        >
+          {isPending ? 'Posting...' : 'Post'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/PostCard.module.css
+++ b/frontend/src/components/PostCard.module.css
@@ -1,9 +1,12 @@
 .card {
-  border: 1px solid #e1e8ed;
-  border-radius: 12px;
   padding: 16px;
-  margin-bottom: 12px;
-  background: #fff;
+  border-bottom: 1px solid #2f3336;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.card:hover {
+  background: rgba(255, 255, 255, 0.03);
 }
 
 .header {
@@ -13,9 +16,35 @@
   margin-bottom: 8px;
 }
 
-.author {
-  font-weight: 600;
-  color: #14171a;
+.authorInfo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.avatarPlaceholder {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #2f3336;
+}
+
+.displayName {
+  font-weight: 700;
+  color: #e7e9ea;
+  font-size: 15px;
+  margin-right: 4px;
+}
+
+.username {
+  color: #71767b;
   font-size: 14px;
 }
 
@@ -27,28 +56,28 @@
 }
 
 .public {
-  background: #e8f5e9;
-  color: #2e7d32;
+  background: #0d3b1e;
+  color: #4caf50;
 }
 
 .friends {
-  background: #e3f2fd;
-  color: #1565c0;
+  background: #0a2a4a;
+  color: #42a5f5;
 }
 
 .private {
-  background: #fce4ec;
-  color: #c62828;
+  background: #3b0d0d;
+  color: #ef5350;
 }
 
 .content {
-  color: #14171a;
+  color: #e7e9ea;
   font-size: 15px;
   line-height: 1.5;
   margin-bottom: 8px;
 }
 
 .date {
-  color: #657786;
+  color: #71767b;
   font-size: 13px;
 }

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -1,21 +1,48 @@
-import type { Post } from '@/types/api'
+import { useNavigate } from 'react-router-dom'
+import type { PostDetail } from '@/types/api'
 import styles from './PostCard.module.css'
 
 interface PostCardProps {
-  post: Post
+  post: PostDetail
 }
 
-const visibilityLabel: Record<Post['visibility'], string> = {
+const visibilityLabel: Record<PostDetail['visibility'], string> = {
   public: 'Public',
   friends: 'Friends',
   private: 'Private',
 }
 
 function PostCard({ post }: PostCardProps) {
+  const navigate = useNavigate()
+
   return (
-    <div className={styles.card}>
+    <div
+      className={styles.card}
+      onClick={() => navigate(`/post/${post.id}`)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') navigate(`/post/${post.id}`)
+      }}
+    >
       <div className={styles.header}>
-        <span className={styles.author}>{post.authorId.slice(0, 8)}</span>
+        <div className={styles.authorInfo}>
+          {post.author.profileImageUrl ? (
+            <img
+              src={post.author.profileImageUrl}
+              alt=""
+              className={styles.avatar}
+            />
+          ) : (
+            <div className={styles.avatarPlaceholder} />
+          )}
+          <div>
+            <span className={styles.displayName}>
+              {post.author.displayName || post.author.username}
+            </span>
+            <span className={styles.username}>@{post.author.username}</span>
+          </div>
+        </div>
         <span className={`${styles.badge} ${styles[post.visibility]}`}>
           {visibilityLabel[post.visibility]}
         </span>

--- a/frontend/src/hooks/usePosts.ts
+++ b/frontend/src/hooks/usePosts.ts
@@ -1,12 +1,41 @@
-import { useQuery } from '@tanstack/react-query'
-import type { APIResponse, Post } from '@/types/api'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import type { APIResponse, PostDetail, CreatePostRequest } from '@/types/api'
 
-async function fetchPosts(): Promise<Post[]> {
+async function fetchPosts(): Promise<PostDetail[]> {
   const res = await fetch('/api/posts')
   if (!res.ok) {
     throw new Error(`Failed to fetch posts: ${res.status}`)
   }
-  const json: APIResponse<Post[]> = await res.json()
+  const json: APIResponse<PostDetail[]> = await res.json()
+  if (!json.success) {
+    throw new Error(json.error ?? 'Unknown error')
+  }
+  return json.data
+}
+
+async function fetchPostDetail(id: string): Promise<PostDetail> {
+  const res = await fetch(`/api/posts/${id}`)
+  if (!res.ok) {
+    throw new Error(`Failed to fetch post: ${res.status}`)
+  }
+  const json: APIResponse<PostDetail> = await res.json()
+  if (!json.success) {
+    throw new Error(json.error ?? 'Unknown error')
+  }
+  return json.data
+}
+
+async function createPost(req: CreatePostRequest): Promise<PostDetail> {
+  const res = await fetch('/api/posts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  })
+  if (!res.ok) {
+    const json = await res.json()
+    throw new Error(json.error ?? `Failed to create post: ${res.status}`)
+  }
+  const json: APIResponse<PostDetail> = await res.json()
   if (!json.success) {
     throw new Error(json.error ?? 'Unknown error')
   }
@@ -17,5 +46,24 @@ export function usePosts() {
   return useQuery({
     queryKey: ['posts'],
     queryFn: fetchPosts,
+  })
+}
+
+export function usePostDetail(id: string) {
+  return useQuery({
+    queryKey: ['post', id],
+    queryFn: () => fetchPostDetail(id),
+    enabled: !!id,
+  })
+}
+
+export function useCreatePost() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: createPost,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['posts'] })
+    },
   })
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import { usePosts } from '@/hooks/usePosts'
 import { useAuth } from '@/hooks/useAuthContext'
 import PostCard from '@/components/PostCard'
+import ComposeForm from '@/components/ComposeForm'
 import styles from './HomePage.module.css'
 
 export default function HomePage() {
@@ -18,6 +19,7 @@ export default function HomePage() {
           </button>
         </div>
       </header>
+      <ComposeForm />
       <main>
         {isLoading && <p>Loading posts...</p>}
         {error && <p>Error: {error.message}</p>}

--- a/frontend/src/pages/PostDetailPage.module.css
+++ b/frontend/src/pages/PostDetailPage.module.css
@@ -1,0 +1,99 @@
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #2f3336;
+  position: sticky;
+  top: 0;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(12px);
+  z-index: 10;
+}
+
+.backButton {
+  background: none;
+  border: none;
+  color: #e7e9ea;
+  font-size: 20px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 9999px;
+  transition: background 0.2s;
+}
+
+.backButton:hover {
+  background: rgba(239, 243, 244, 0.1);
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.post {
+  padding: 16px;
+}
+
+.authorRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.avatarPlaceholder {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #2f3336;
+}
+
+.authorText {
+  display: flex;
+  flex-direction: column;
+}
+
+.displayName {
+  font-weight: 700;
+  color: #e7e9ea;
+  font-size: 15px;
+}
+
+.username {
+  color: #71767b;
+  font-size: 14px;
+}
+
+.content {
+  color: #e7e9ea;
+  font-size: 17px;
+  line-height: 1.6;
+  margin-bottom: 16px;
+}
+
+.date {
+  color: #71767b;
+  font-size: 14px;
+  padding-top: 16px;
+  border-top: 1px solid #2f3336;
+  display: block;
+}
+
+.status {
+  padding: 32px 16px;
+  text-align: center;
+  color: #71767b;
+}

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,0 +1,47 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { usePostDetail } from '@/hooks/usePosts'
+import styles from './PostDetailPage.module.css'
+
+export default function PostDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { data: post, isLoading, error } = usePostDetail(id ?? '')
+
+  if (isLoading) return <p className={styles.status}>Loading...</p>
+  if (error) return <p className={styles.status}>Error: {error.message}</p>
+  if (!post) return <p className={styles.status}>Post not found.</p>
+
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <button className={styles.backButton} onClick={() => navigate(-1)}>
+          &larr;
+        </button>
+        <h1 className={styles.title}>Post</h1>
+      </header>
+      <article className={styles.post}>
+        <div className={styles.authorRow}>
+          {post.author.profileImageUrl ? (
+            <img
+              src={post.author.profileImageUrl}
+              alt=""
+              className={styles.avatar}
+            />
+          ) : (
+            <div className={styles.avatarPlaceholder} />
+          )}
+          <div className={styles.authorText}>
+            <span className={styles.displayName}>
+              {post.author.displayName || post.author.username}
+            </span>
+            <span className={styles.username}>@{post.author.username}</span>
+          </div>
+        </div>
+        <p className={styles.content}>{post.content}</p>
+        <span className={styles.date}>
+          {new Date(post.createdAt).toLocaleString()}
+        </span>
+      </article>
+    </div>
+  )
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -54,3 +54,24 @@ export interface UpdateProfileRequest {
   profileImageUrl: string
   headerImageUrl: string
 }
+
+export interface CreatePostRequest {
+  content: string
+  visibility: 'public' | 'friends' | 'private'
+}
+
+export interface PostAuthor {
+  username: string
+  displayName: string
+  profileImageUrl: string
+}
+
+export interface PostDetail {
+  id: string
+  authorId: string
+  content: string
+  visibility: 'public' | 'friends' | 'private'
+  author: PostAuthor
+  createdAt: string
+  updatedAt: string
+}


### PR DESCRIPTION
## Summary
- Mock PostService를 제거하고 PostgreSQL 기반 실제 CRUD 구현
- 280자 제한 텍스트 포스트 작성 API (`POST /api/posts`, 인증 필요) 및 단일 포스트 조회 API (`GET /api/posts/:id`)
- 작성자 프로필 정보(username, displayName, profileImageUrl)를 JOIN하여 함께 반환
- 프론트엔드: ComposeForm (글자 수 인디케이터), PostDetailPage, PostCard 작성자 정보 표시

## Changes

### Backend
- `migrations/003_create_posts` — posts 테이블 생성 (UUID PK, FK→users, VARCHAR 280)
- `PostRepository` — Create, FindByID (JOIN users), FindAll
- `PostService` — 280자 검증, CreatePost/GetPostByID/GetPosts
- `PostHandler` — CreatePost (인증), GetPostByID, GetPosts
- `post_service_test.go` — 5개 유닛 테스트

### Frontend
- `ComposeForm` — 280자 textarea + 남은 글자 수 카운터
- `PostDetailPage` — `/post/:id` 단일 포스트 상세 페이지
- `PostCard` — 작성자 프로필 표시, 클릭 시 상세 페이지 이동
- `usePosts` — useCreatePost mutation, usePostDetail query 추가

## Test plan
- [x] `go build ./...` 통과
- [x] `go test ./...` 통과 (5개 테스트)
- [x] `bun run build` 통과
- [x] `bun run lint` 통과
- [x] 로그인 후 포스트 작성 → 피드에 즉시 반영 확인
- [x] 280자 초과 입력 시 전송 버튼 비활성화 확인
- [x] 포스트 클릭 → 상세 페이지 이동 및 작성자 정보 표시 확인

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)