### PR TITLE
feat: 사용자 간 팔로우/언팔로우 관계 시스템 구축

### DIFF
--- a/backend/internal/dto/follow_dto.go
+++ b/backend/internal/dto/follow_dto.go
@@ -1,0 +1,30 @@
+package dto
+
+import "github.com/kitae0522/twitter-clone-claude/backend/internal/model"
+
+type FollowStatusResponse struct {
+	Following bool `json:"following"`
+}
+
+type FollowUserResponse struct {
+	ID              string `json:"id"`
+	Username        string `json:"username"`
+	DisplayName     string `json:"displayName"`
+	Bio             string `json:"bio"`
+	ProfileImageURL string `json:"profileImageUrl"`
+}
+
+type FollowListResponse struct {
+	Users []FollowUserResponse `json:"users"`
+	Total int                  `json:"total"`
+}
+
+func ToFollowUserResponse(u *model.User) FollowUserResponse {
+	return FollowUserResponse{
+		ID:              u.ID.String(),
+		Username:        u.Username,
+		DisplayName:     u.DisplayName,
+		Bio:             u.Bio,
+		ProfileImageURL: u.ProfileImageURL,
+	}
+}

--- a/backend/internal/dto/user_dto.go
+++ b/backend/internal/dto/user_dto.go
@@ -17,11 +17,14 @@ type ProfileResponse struct {
 	Bio             string `json:"bio"`
 	ProfileImageURL string `json:"profileImageUrl"`
 	HeaderImageURL  string `json:"headerImageUrl"`
+	FollowersCount  int    `json:"followersCount"`
+	FollowingCount  int    `json:"followingCount"`
+	IsFollowing     bool   `json:"isFollowing"`
 	CreatedAt       string `json:"createdAt"`
 	UpdatedAt       string `json:"updatedAt"`
 }
 
-func ToProfileResponse(u *model.User) ProfileResponse {
+func ToProfileResponse(u *model.User, followersCount, followingCount int, isFollowing bool) ProfileResponse {
 	return ProfileResponse{
 		ID:              u.ID.String(),
 		Username:        u.Username,
@@ -29,6 +32,9 @@ func ToProfileResponse(u *model.User) ProfileResponse {
 		Bio:             u.Bio,
 		ProfileImageURL: u.ProfileImageURL,
 		HeaderImageURL:  u.HeaderImageURL,
+		FollowersCount:  followersCount,
+		FollowingCount:  followingCount,
+		IsFollowing:     isFollowing,
 		CreatedAt:       u.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt:       u.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 	}

--- a/backend/internal/handler/follow_handler.go
+++ b/backend/internal/handler/follow_handler.go
@@ -1,0 +1,105 @@
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/service"
+)
+
+type FollowHandler struct {
+	followService service.FollowService
+}
+
+func NewFollowHandler(followService service.FollowService) *FollowHandler {
+	return &FollowHandler{followService: followService}
+}
+
+func (h *FollowHandler) Follow(c *fiber.Ctx) error {
+	userIDStr, ok := c.Locals("userID").(string)
+	if !ok {
+		return respondError(c, apperror.Unauthorized("not authenticated"))
+	}
+
+	followerID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return respondError(c, apperror.Unauthorized("invalid user ID"))
+	}
+
+	handle := c.Params("handle")
+	if handle == "" {
+		return respondError(c, apperror.BadRequest("handle is required"))
+	}
+
+	resp, err := h.followService.Follow(c.Context(), followerID, handle)
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    resp,
+	})
+}
+
+func (h *FollowHandler) Unfollow(c *fiber.Ctx) error {
+	userIDStr, ok := c.Locals("userID").(string)
+	if !ok {
+		return respondError(c, apperror.Unauthorized("not authenticated"))
+	}
+
+	followerID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return respondError(c, apperror.Unauthorized("invalid user ID"))
+	}
+
+	handle := c.Params("handle")
+	if handle == "" {
+		return respondError(c, apperror.BadRequest("handle is required"))
+	}
+
+	resp, err := h.followService.Unfollow(c.Context(), followerID, handle)
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    resp,
+	})
+}
+
+func (h *FollowHandler) GetFollowing(c *fiber.Ctx) error {
+	handle := c.Params("handle")
+	if handle == "" {
+		return respondError(c, apperror.BadRequest("handle is required"))
+	}
+
+	resp, err := h.followService.GetFollowing(c.Context(), handle)
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    resp,
+	})
+}
+
+func (h *FollowHandler) GetFollowers(c *fiber.Ctx) error {
+	handle := c.Params("handle")
+	if handle == "" {
+		return respondError(c, apperror.BadRequest("handle is required"))
+	}
+
+	resp, err := h.followService.GetFollowers(c.Context(), handle)
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    resp,
+	})
+}

--- a/backend/internal/handler/user_handler.go
+++ b/backend/internal/handler/user_handler.go
@@ -22,7 +22,14 @@ func (h *UserHandler) GetProfile(c *fiber.Ctx) error {
 		return respondError(c, apperror.BadRequest("handle is required"))
 	}
 
-	profile, err := h.userService.GetProfile(c.Context(), handle)
+	var viewerID *uuid.UUID
+	if userIDStr, ok := c.Locals("userID").(string); ok {
+		if id, err := uuid.Parse(userIDStr); err == nil {
+			viewerID = &id
+		}
+	}
+
+	profile, err := h.userService.GetProfile(c.Context(), handle, viewerID)
 	if err != nil {
 		return respondError(c, err)
 	}

--- a/backend/internal/middleware/auth_middleware.go
+++ b/backend/internal/middleware/auth_middleware.go
@@ -6,6 +6,37 @@ import (
 	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
 )
 
+func OptionalAuth(jwtSecret string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		tokenStr := c.Cookies("token")
+		if tokenStr == "" {
+			return c.Next()
+		}
+
+		token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, jwt.ErrSignatureInvalid
+			}
+			return []byte(jwtSecret), nil
+		})
+		if err != nil || !token.Valid {
+			return c.Next()
+		}
+
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			return c.Next()
+		}
+
+		sub, ok := claims["sub"].(string)
+		if ok {
+			c.Locals("userID", sub)
+		}
+
+		return c.Next()
+	}
+}
+
 func AuthRequired(jwtSecret string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		tokenStr := c.Cookies("token")

--- a/backend/internal/model/follow.go
+++ b/backend/internal/model/follow.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Follow struct {
+	FollowerID  uuid.UUID
+	FollowingID uuid.UUID
+	CreatedAt   time.Time
+}

--- a/backend/internal/repository/follow_repository.go
+++ b/backend/internal/repository/follow_repository.go
@@ -1,0 +1,111 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/model"
+)
+
+type FollowRepository interface {
+	Follow(ctx context.Context, followerID, followingID uuid.UUID) error
+	Unfollow(ctx context.Context, followerID, followingID uuid.UUID) (bool, error)
+	IsFollowing(ctx context.Context, followerID, followingID uuid.UUID) (bool, error)
+	GetFollowing(ctx context.Context, userID uuid.UUID) ([]*model.User, error)
+	GetFollowers(ctx context.Context, userID uuid.UUID) ([]*model.User, error)
+	CountFollowing(ctx context.Context, userID uuid.UUID) (int, error)
+	CountFollowers(ctx context.Context, userID uuid.UUID) (int, error)
+}
+
+type followRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewFollowRepository(pool *pgxpool.Pool) FollowRepository {
+	return &followRepository{pool: pool}
+}
+
+func (r *followRepository) Follow(ctx context.Context, followerID, followingID uuid.UUID) error {
+	query := `INSERT INTO follows (follower_id, following_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`
+	_, err := r.pool.Exec(ctx, query, followerID, followingID)
+	return err
+}
+
+func (r *followRepository) Unfollow(ctx context.Context, followerID, followingID uuid.UUID) (bool, error) {
+	query := `DELETE FROM follows WHERE follower_id = $1 AND following_id = $2`
+	tag, err := r.pool.Exec(ctx, query, followerID, followingID)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (r *followRepository) IsFollowing(ctx context.Context, followerID, followingID uuid.UUID) (bool, error) {
+	var exists bool
+	query := `SELECT EXISTS(SELECT 1 FROM follows WHERE follower_id = $1 AND following_id = $2)`
+	err := r.pool.QueryRow(ctx, query, followerID, followingID).Scan(&exists)
+	return exists, err
+}
+
+func (r *followRepository) GetFollowing(ctx context.Context, userID uuid.UUID) ([]*model.User, error) {
+	query := `
+		SELECT u.id, u.email, u.password_hash, u.username, u.display_name, u.bio, u.profile_image_url, u.header_image_url, u.created_at, u.updated_at
+		FROM follows f
+		JOIN users u ON u.id = f.following_id
+		WHERE f.follower_id = $1
+		ORDER BY f.created_at DESC`
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []*model.User
+	for rows.Next() {
+		u := &model.User{}
+		if err := rows.Scan(&u.ID, &u.Email, &u.PasswordHash, &u.Username, &u.DisplayName, &u.Bio, &u.ProfileImageURL, &u.HeaderImageURL, &u.CreatedAt, &u.UpdatedAt); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
+}
+
+func (r *followRepository) GetFollowers(ctx context.Context, userID uuid.UUID) ([]*model.User, error) {
+	query := `
+		SELECT u.id, u.email, u.password_hash, u.username, u.display_name, u.bio, u.profile_image_url, u.header_image_url, u.created_at, u.updated_at
+		FROM follows f
+		JOIN users u ON u.id = f.follower_id
+		WHERE f.following_id = $1
+		ORDER BY f.created_at DESC`
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []*model.User
+	for rows.Next() {
+		u := &model.User{}
+		if err := rows.Scan(&u.ID, &u.Email, &u.PasswordHash, &u.Username, &u.DisplayName, &u.Bio, &u.ProfileImageURL, &u.HeaderImageURL, &u.CreatedAt, &u.UpdatedAt); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, rows.Err()
+}
+
+func (r *followRepository) CountFollowing(ctx context.Context, userID uuid.UUID) (int, error) {
+	var count int
+	err := r.pool.QueryRow(ctx, `SELECT COUNT(*) FROM follows WHERE follower_id = $1`, userID).Scan(&count)
+	return count, err
+}
+
+func (r *followRepository) CountFollowers(ctx context.Context, userID uuid.UUID) (int, error) {
+	var count int
+	err := r.pool.QueryRow(ctx, `SELECT COUNT(*) FROM follows WHERE following_id = $1`, userID).Scan(&count)
+	return count, err
+}

--- a/backend/internal/service/auth_service_test.go
+++ b/backend/internal/service/auth_service_test.go
@@ -54,6 +54,21 @@ func (m *mockUserRepo) ExistsByEmail(_ context.Context, email string) (bool, err
 	return m.emailExists[email], nil
 }
 
+func (m *mockUserRepo) FindByUsername(_ context.Context, username string) (*model.User, error) {
+	for _, u := range m.users {
+		if u.Username == username {
+			return u, nil
+		}
+	}
+	return nil, pgx.ErrNoRows
+}
+
+func (m *mockUserRepo) Update(_ context.Context, user *model.User) error {
+	m.users[user.Email] = user
+	m.usersByID[user.ID] = user
+	return nil
+}
+
 func (m *mockUserRepo) ExistsByUsername(_ context.Context, username string) (bool, error) {
 	return m.nameExists[username], nil
 }

--- a/backend/internal/service/follow_service.go
+++ b/backend/internal/service/follow_service.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/repository"
+)
+
+type FollowService interface {
+	Follow(ctx context.Context, followerID uuid.UUID, targetHandle string) (*dto.FollowStatusResponse, error)
+	Unfollow(ctx context.Context, followerID uuid.UUID, targetHandle string) (*dto.FollowStatusResponse, error)
+	GetFollowing(ctx context.Context, handle string) (*dto.FollowListResponse, error)
+	GetFollowers(ctx context.Context, handle string) (*dto.FollowListResponse, error)
+}
+
+type followService struct {
+	followRepo repository.FollowRepository
+	userRepo   repository.UserRepository
+}
+
+func NewFollowService(followRepo repository.FollowRepository, userRepo repository.UserRepository) FollowService {
+	return &followService{followRepo: followRepo, userRepo: userRepo}
+}
+
+func (s *followService) Follow(ctx context.Context, followerID uuid.UUID, targetHandle string) (*dto.FollowStatusResponse, error) {
+	targetUser, err := s.userRepo.FindByUsername(ctx, targetHandle)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, apperror.NotFound("user not found")
+		}
+		return nil, apperror.Internal("failed to find user")
+	}
+
+	if followerID == targetUser.ID {
+		return nil, apperror.BadRequest("cannot follow yourself")
+	}
+
+	already, err := s.followRepo.IsFollowing(ctx, followerID, targetUser.ID)
+	if err != nil {
+		return nil, apperror.Internal("failed to check follow status")
+	}
+	if already {
+		return nil, apperror.Conflict("already following this user")
+	}
+
+	if err := s.followRepo.Follow(ctx, followerID, targetUser.ID); err != nil {
+		return nil, apperror.Internal("failed to follow user")
+	}
+
+	return &dto.FollowStatusResponse{Following: true}, nil
+}
+
+func (s *followService) Unfollow(ctx context.Context, followerID uuid.UUID, targetHandle string) (*dto.FollowStatusResponse, error) {
+	targetUser, err := s.userRepo.FindByUsername(ctx, targetHandle)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, apperror.NotFound("user not found")
+		}
+		return nil, apperror.Internal("failed to find user")
+	}
+
+	if followerID == targetUser.ID {
+		return nil, apperror.BadRequest("cannot unfollow yourself")
+	}
+
+	removed, err := s.followRepo.Unfollow(ctx, followerID, targetUser.ID)
+	if err != nil {
+		return nil, apperror.Internal("failed to unfollow user")
+	}
+	if !removed {
+		return nil, apperror.NotFound("not following this user")
+	}
+
+	return &dto.FollowStatusResponse{Following: false}, nil
+}
+
+func (s *followService) GetFollowing(ctx context.Context, handle string) (*dto.FollowListResponse, error) {
+	user, err := s.userRepo.FindByUsername(ctx, handle)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, apperror.NotFound("user not found")
+		}
+		return nil, apperror.Internal("failed to find user")
+	}
+
+	users, err := s.followRepo.GetFollowing(ctx, user.ID)
+	if err != nil {
+		return nil, apperror.Internal("failed to get following list")
+	}
+
+	followUsers := make([]dto.FollowUserResponse, len(users))
+	for i, u := range users {
+		followUsers[i] = dto.ToFollowUserResponse(u)
+	}
+
+	return &dto.FollowListResponse{Users: followUsers, Total: len(followUsers)}, nil
+}
+
+func (s *followService) GetFollowers(ctx context.Context, handle string) (*dto.FollowListResponse, error) {
+	user, err := s.userRepo.FindByUsername(ctx, handle)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, apperror.NotFound("user not found")
+		}
+		return nil, apperror.Internal("failed to find user")
+	}
+
+	users, err := s.followRepo.GetFollowers(ctx, user.ID)
+	if err != nil {
+		return nil, apperror.Internal("failed to get followers list")
+	}
+
+	followUsers := make([]dto.FollowUserResponse, len(users))
+	for i, u := range users {
+		followUsers[i] = dto.ToFollowUserResponse(u)
+	}
+
+	return &dto.FollowListResponse{Users: followUsers, Total: len(followUsers)}, nil
+}

--- a/backend/internal/service/follow_service_test.go
+++ b/backend/internal/service/follow_service_test.go
@@ -1,0 +1,303 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/model"
+)
+
+// mockFollowRepo implements repository.FollowRepository for testing
+type mockFollowRepo struct {
+	follows map[string]bool // "followerID:followingID" -> true
+	users   map[uuid.UUID]*model.User
+}
+
+func newMockFollowRepo() *mockFollowRepo {
+	return &mockFollowRepo{
+		follows: make(map[string]bool),
+		users:   make(map[uuid.UUID]*model.User),
+	}
+}
+
+func followKey(a, b uuid.UUID) string {
+	return a.String() + ":" + b.String()
+}
+
+func (m *mockFollowRepo) Follow(_ context.Context, followerID, followingID uuid.UUID) error {
+	m.follows[followKey(followerID, followingID)] = true
+	return nil
+}
+
+func (m *mockFollowRepo) Unfollow(_ context.Context, followerID, followingID uuid.UUID) (bool, error) {
+	key := followKey(followerID, followingID)
+	if m.follows[key] {
+		delete(m.follows, key)
+		return true, nil
+	}
+	return false, nil
+}
+
+func (m *mockFollowRepo) IsFollowing(_ context.Context, followerID, followingID uuid.UUID) (bool, error) {
+	return m.follows[followKey(followerID, followingID)], nil
+}
+
+func (m *mockFollowRepo) GetFollowing(_ context.Context, userID uuid.UUID) ([]*model.User, error) {
+	var result []*model.User
+	prefix := userID.String() + ":"
+	for key := range m.follows {
+		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+			followingIDStr := key[len(prefix):]
+			followingID, _ := uuid.Parse(followingIDStr)
+			if u, ok := m.users[followingID]; ok {
+				result = append(result, u)
+			}
+		}
+	}
+	return result, nil
+}
+
+func (m *mockFollowRepo) GetFollowers(_ context.Context, userID uuid.UUID) ([]*model.User, error) {
+	var result []*model.User
+	suffix := ":" + userID.String()
+	for key := range m.follows {
+		if len(key) > len(suffix) && key[len(key)-len(suffix):] == suffix {
+			followerIDStr := key[:len(key)-len(suffix)]
+			followerID, _ := uuid.Parse(followerIDStr)
+			if u, ok := m.users[followerID]; ok {
+				result = append(result, u)
+			}
+		}
+	}
+	return result, nil
+}
+
+func (m *mockFollowRepo) CountFollowing(_ context.Context, userID uuid.UUID) (int, error) {
+	count := 0
+	prefix := userID.String() + ":"
+	for key := range m.follows {
+		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m *mockFollowRepo) CountFollowers(_ context.Context, userID uuid.UUID) (int, error) {
+	count := 0
+	suffix := ":" + userID.String()
+	for key := range m.follows {
+		if len(key) > len(suffix) && key[len(key)-len(suffix):] == suffix {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// mockUserRepoForFollow implements repository.UserRepository for follow tests
+type mockUserRepoForFollow struct {
+	users       map[string]*model.User // username -> user
+	usersByID   map[uuid.UUID]*model.User
+	emailExists map[string]bool
+	nameExists  map[string]bool
+}
+
+func newMockUserRepoForFollow() *mockUserRepoForFollow {
+	return &mockUserRepoForFollow{
+		users:       make(map[string]*model.User),
+		usersByID:   make(map[uuid.UUID]*model.User),
+		emailExists: make(map[string]bool),
+		nameExists:  make(map[string]bool),
+	}
+}
+
+func (m *mockUserRepoForFollow) addUser(u *model.User) {
+	m.users[u.Username] = u
+	m.usersByID[u.ID] = u
+	m.emailExists[u.Email] = true
+	m.nameExists[u.Username] = true
+}
+
+func (m *mockUserRepoForFollow) Create(_ context.Context, user *model.User) error {
+	user.ID = uuid.New()
+	m.addUser(user)
+	return nil
+}
+
+func (m *mockUserRepoForFollow) FindByEmail(_ context.Context, email string) (*model.User, error) {
+	for _, u := range m.users {
+		if u.Email == email {
+			return u, nil
+		}
+	}
+	return nil, pgx.ErrNoRows
+}
+
+func (m *mockUserRepoForFollow) FindByID(_ context.Context, id uuid.UUID) (*model.User, error) {
+	if u, ok := m.usersByID[id]; ok {
+		return u, nil
+	}
+	return nil, pgx.ErrNoRows
+}
+
+func (m *mockUserRepoForFollow) FindByUsername(_ context.Context, username string) (*model.User, error) {
+	if u, ok := m.users[username]; ok {
+		return u, nil
+	}
+	return nil, pgx.ErrNoRows
+}
+
+func (m *mockUserRepoForFollow) Update(_ context.Context, user *model.User) error {
+	m.users[user.Username] = user
+	m.usersByID[user.ID] = user
+	return nil
+}
+
+func (m *mockUserRepoForFollow) ExistsByEmail(_ context.Context, email string) (bool, error) {
+	return m.emailExists[email], nil
+}
+
+func (m *mockUserRepoForFollow) ExistsByUsername(_ context.Context, username string) (bool, error) {
+	return m.nameExists[username], nil
+}
+
+func setupFollowTest() (*followService, *mockFollowRepo, *mockUserRepoForFollow, *model.User, *model.User) {
+	userRepo := newMockUserRepoForFollow()
+	followRepo := newMockFollowRepo()
+
+	user1 := &model.User{ID: uuid.New(), Username: "alice", Email: "alice@test.com", DisplayName: "Alice"}
+	user2 := &model.User{ID: uuid.New(), Username: "bob", Email: "bob@test.com", DisplayName: "Bob"}
+	userRepo.addUser(user1)
+	userRepo.addUser(user2)
+	followRepo.users[user1.ID] = user1
+	followRepo.users[user2.ID] = user2
+
+	svc := &followService{followRepo: followRepo, userRepo: userRepo}
+	return svc, followRepo, userRepo, user1, user2
+}
+
+func TestFollow_Success(t *testing.T) {
+	svc, _, _, user1, _ := setupFollowTest()
+
+	resp, err := svc.Follow(context.Background(), user1.ID, "bob")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !resp.Following {
+		t.Error("expected following to be true")
+	}
+}
+
+func TestFollow_SelfFollow(t *testing.T) {
+	svc, _, _, user1, _ := setupFollowTest()
+
+	_, err := svc.Follow(context.Background(), user1.ID, "alice")
+	if err == nil {
+		t.Fatal("expected error for self follow")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok || appErr.Code != 400 {
+		t.Errorf("expected 400 error, got %v", err)
+	}
+}
+
+func TestFollow_AlreadyFollowing(t *testing.T) {
+	svc, _, _, user1, _ := setupFollowTest()
+
+	_, _ = svc.Follow(context.Background(), user1.ID, "bob")
+	_, err := svc.Follow(context.Background(), user1.ID, "bob")
+	if err == nil {
+		t.Fatal("expected error for already following")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok || appErr.Code != 409 {
+		t.Errorf("expected 409 error, got %v", err)
+	}
+}
+
+func TestFollow_UserNotFound(t *testing.T) {
+	svc, _, _, user1, _ := setupFollowTest()
+
+	_, err := svc.Follow(context.Background(), user1.ID, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for user not found")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok || appErr.Code != 404 {
+		t.Errorf("expected 404 error, got %v", err)
+	}
+}
+
+func TestUnfollow_Success(t *testing.T) {
+	svc, _, _, user1, _ := setupFollowTest()
+
+	_, _ = svc.Follow(context.Background(), user1.ID, "bob")
+	resp, err := svc.Unfollow(context.Background(), user1.ID, "bob")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Following {
+		t.Error("expected following to be false")
+	}
+}
+
+func TestUnfollow_NotFollowing(t *testing.T) {
+	svc, _, _, user1, _ := setupFollowTest()
+
+	_, err := svc.Unfollow(context.Background(), user1.ID, "bob")
+	if err == nil {
+		t.Fatal("expected error for not following")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok || appErr.Code != 404 {
+		t.Errorf("expected 404 error, got %v", err)
+	}
+}
+
+func TestUnfollow_SelfUnfollow(t *testing.T) {
+	svc, _, _, user1, _ := setupFollowTest()
+
+	_, err := svc.Unfollow(context.Background(), user1.ID, "alice")
+	if err == nil {
+		t.Fatal("expected error for self unfollow")
+	}
+	appErr, ok := err.(*apperror.AppError)
+	if !ok || appErr.Code != 400 {
+		t.Errorf("expected 400 error, got %v", err)
+	}
+}
+
+func TestGetFollowing_Success(t *testing.T) {
+	svc, _, _, user1, _ := setupFollowTest()
+
+	_, _ = svc.Follow(context.Background(), user1.ID, "bob")
+	resp, err := svc.GetFollowing(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("expected 1 following, got %d", resp.Total)
+	}
+	if resp.Users[0].Username != "bob" {
+		t.Errorf("expected bob, got %s", resp.Users[0].Username)
+	}
+}
+
+func TestGetFollowers_Success(t *testing.T) {
+	svc, _, _, user1, _ := setupFollowTest()
+
+	_, _ = svc.Follow(context.Background(), user1.ID, "bob")
+	resp, err := svc.GetFollowers(context.Background(), "bob")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("expected 1 follower, got %d", resp.Total)
+	}
+	if resp.Users[0].Username != "alice" {
+		t.Errorf("expected alice, got %s", resp.Users[0].Username)
+	}
+}

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -11,19 +11,20 @@ import (
 )
 
 type UserService interface {
-	GetProfile(ctx context.Context, username string) (*dto.ProfileResponse, error)
+	GetProfile(ctx context.Context, username string, viewerID *uuid.UUID) (*dto.ProfileResponse, error)
 	UpdateProfile(ctx context.Context, userID uuid.UUID, req dto.UpdateProfileRequest) (*dto.UserResponse, error)
 }
 
 type userService struct {
-	userRepo repository.UserRepository
+	userRepo   repository.UserRepository
+	followRepo repository.FollowRepository
 }
 
-func NewUserService(userRepo repository.UserRepository) UserService {
-	return &userService{userRepo: userRepo}
+func NewUserService(userRepo repository.UserRepository, followRepo repository.FollowRepository) UserService {
+	return &userService{userRepo: userRepo, followRepo: followRepo}
 }
 
-func (s *userService) GetProfile(ctx context.Context, username string) (*dto.ProfileResponse, error) {
+func (s *userService) GetProfile(ctx context.Context, username string, viewerID *uuid.UUID) (*dto.ProfileResponse, error) {
 	user, err := s.userRepo.FindByUsername(ctx, username)
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -32,7 +33,25 @@ func (s *userService) GetProfile(ctx context.Context, username string) (*dto.Pro
 		return nil, apperror.Internal("failed to find user")
 	}
 
-	resp := dto.ToProfileResponse(user)
+	followersCount, err := s.followRepo.CountFollowers(ctx, user.ID)
+	if err != nil {
+		return nil, apperror.Internal("failed to count followers")
+	}
+
+	followingCount, err := s.followRepo.CountFollowing(ctx, user.ID)
+	if err != nil {
+		return nil, apperror.Internal("failed to count following")
+	}
+
+	isFollowing := false
+	if viewerID != nil && *viewerID != user.ID {
+		isFollowing, err = s.followRepo.IsFollowing(ctx, *viewerID, user.ID)
+		if err != nil {
+			return nil, apperror.Internal("failed to check follow status")
+		}
+	}
+
+	resp := dto.ToProfileResponse(user, followersCount, followingCount, isFollowing)
 	return &resp, nil
 }
 

--- a/backend/internal/service/user_service_test.go
+++ b/backend/internal/service/user_service_test.go
@@ -5,41 +5,22 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
 	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
 	"github.com/kitae0522/twitter-clone-claude/backend/internal/model"
 )
 
-func (m *mockUserRepo) FindByUsername(_ context.Context, username string) (*model.User, error) {
-	for _, u := range m.users {
-		if u.Username == username {
-			return u, nil
-		}
-	}
-	return nil, pgx.ErrNoRows
-}
-
-func (m *mockUserRepo) Update(_ context.Context, user *model.User) error {
-	m.usersByID[user.ID] = user
-	m.users[user.Email] = user
-	if user.Username != "" {
-		m.nameExists[user.Username] = true
-	}
-	return nil
-}
-
 func TestGetProfile_Success(t *testing.T) {
 	repo := newMockUserRepo()
-	svc := NewUserService(repo)
+	followRepo := newMockFollowRepo()
+	svc := NewUserService(repo, followRepo)
 
-	// seed a user via auth service
 	authSvc := NewAuthService(repo, "test-secret", 24)
 	_, _ = authSvc.Register(context.Background(), dto.RegisterRequest{
 		Email: "profile@example.com", Username: "profileuser", Password: "password123",
 	})
 
-	profile, err := svc.GetProfile(context.Background(), "profileuser")
+	profile, err := svc.GetProfile(context.Background(), "profileuser", nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -50,9 +31,10 @@ func TestGetProfile_Success(t *testing.T) {
 
 func TestGetProfile_NotFound(t *testing.T) {
 	repo := newMockUserRepo()
-	svc := NewUserService(repo)
+	followRepo := newMockFollowRepo()
+	svc := NewUserService(repo, followRepo)
 
-	_, err := svc.GetProfile(context.Background(), "nonexistent")
+	_, err := svc.GetProfile(context.Background(), "nonexistent", nil)
 	if err == nil {
 		t.Fatal("expected error for nonexistent user")
 	}
@@ -67,9 +49,9 @@ func TestGetProfile_NotFound(t *testing.T) {
 
 func TestUpdateProfile_Success(t *testing.T) {
 	repo := newMockUserRepo()
-	svc := NewUserService(repo)
+	followRepo := newMockFollowRepo()
+	svc := NewUserService(repo, followRepo)
 
-	// seed a user
 	user := &model.User{
 		Email:        "update@example.com",
 		PasswordHash: "hash",
@@ -93,9 +75,9 @@ func TestUpdateProfile_Success(t *testing.T) {
 
 func TestUpdateProfile_DuplicateUsername(t *testing.T) {
 	repo := newMockUserRepo()
-	svc := NewUserService(repo)
+	followRepo := newMockFollowRepo()
+	svc := NewUserService(repo, followRepo)
 
-	// seed two users
 	user1 := &model.User{
 		Email: "user1@example.com", PasswordHash: "hash", Username: "user1", DisplayName: "User 1",
 	}
@@ -107,7 +89,7 @@ func TestUpdateProfile_DuplicateUsername(t *testing.T) {
 
 	_, err := svc.UpdateProfile(context.Background(), user2.ID, dto.UpdateProfileRequest{
 		DisplayName: "User 2",
-		Username:    "user1", // taken by user1
+		Username:    "user1",
 	})
 	if err == nil {
 		t.Fatal("expected error for duplicate username")
@@ -123,7 +105,8 @@ func TestUpdateProfile_DuplicateUsername(t *testing.T) {
 
 func TestUpdateProfile_NotFound(t *testing.T) {
 	repo := newMockUserRepo()
-	svc := NewUserService(repo)
+	followRepo := newMockFollowRepo()
+	svc := NewUserService(repo, followRepo)
 
 	_, err := svc.UpdateProfile(context.Background(), uuid.New(), dto.UpdateProfileRequest{
 		DisplayName: "Nobody",

--- a/backend/main.go
+++ b/backend/main.go
@@ -39,7 +39,11 @@ func main() {
 	authService := service.NewAuthService(userRepo, cfg.JWTSecret, cfg.JWTExpiryHours)
 	authHandler := handler.NewAuthHandler(authService)
 
-	userService := service.NewUserService(userRepo)
+	followRepo := repository.NewFollowRepository(pool)
+	followService := service.NewFollowService(followRepo, userRepo)
+	followHandler := handler.NewFollowHandler(followService)
+
+	userService := service.NewUserService(userRepo, followRepo)
 	userHandler := handler.NewUserHandler(userService)
 
 	api := app.Group("/api")
@@ -56,7 +60,11 @@ func main() {
 
 	users := api.Group("/users")
 	users.Put("/profile", middleware.AuthRequired(cfg.JWTSecret), userHandler.UpdateProfile)
-	users.Get("/:handle", userHandler.GetProfile)
+	users.Post("/:handle/follow", middleware.AuthRequired(cfg.JWTSecret), followHandler.Follow)
+	users.Delete("/:handle/follow", middleware.AuthRequired(cfg.JWTSecret), followHandler.Unfollow)
+	users.Get("/:handle/following", followHandler.GetFollowing)
+	users.Get("/:handle/followers", followHandler.GetFollowers)
+	users.Get("/:handle", middleware.OptionalAuth(cfg.JWTSecret), userHandler.GetProfile)
 
 	log.Fatal(app.Listen(":8080"))
 }

--- a/backend/migrations/004_create_follows.down.sql
+++ b/backend/migrations/004_create_follows.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS follows;

--- a/backend/migrations/004_create_follows.up.sql
+++ b/backend/migrations/004_create_follows.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE follows (
+    follower_id  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    following_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (follower_id, following_id),
+    CONSTRAINT no_self_follow CHECK (follower_id <> following_id)
+);
+CREATE INDEX idx_follows_follower_id  ON follows(follower_id);
+CREATE INDEX idx_follows_following_id ON follows(following_id);

--- a/frontend/src/components/FollowListModal.module.css
+++ b/frontend/src/components/FollowListModal.module.css
@@ -1,0 +1,114 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(91, 112, 131, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+}
+
+.modal {
+  background: #000;
+  border-radius: 16px;
+  width: 100%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0 16px;
+  height: 53px;
+  position: sticky;
+  top: 0;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(12px);
+  z-index: 1;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: #e7e9ea;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 9999px;
+  transition: background 0.2s;
+}
+
+.closeButton:hover {
+  background: rgba(239, 243, 244, 0.1);
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.list {
+  padding: 0;
+}
+
+.userItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.userItem:hover {
+  background: rgba(239, 243, 244, 0.03);
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #333639;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.userInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.displayName {
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.handle {
+  color: #71767b;
+  font-size: 15px;
+}
+
+.bio {
+  margin-top: 4px;
+  font-size: 15px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.empty {
+  padding: 32px 16px;
+  text-align: center;
+  color: #71767b;
+}
+
+.loading {
+  padding: 32px 16px;
+  text-align: center;
+  color: #71767b;
+}

--- a/frontend/src/components/FollowListModal.tsx
+++ b/frontend/src/components/FollowListModal.tsx
@@ -1,0 +1,78 @@
+import { useNavigate } from 'react-router-dom'
+import { useFollowers, useFollowing } from '@/hooks/useFollow'
+import styles from './FollowListModal.module.css'
+
+interface Props {
+  handle: string
+  type: 'followers' | 'following'
+  onClose: () => void
+}
+
+export default function FollowListModal({ handle, type, onClose }: Props) {
+  const navigate = useNavigate()
+  const { data: followingData, isLoading: followingLoading } = useFollowing(
+    handle,
+    type === 'following',
+  )
+  const { data: followersData, isLoading: followersLoading } = useFollowers(
+    handle,
+    type === 'followers',
+  )
+
+  const data = type === 'following' ? followingData : followersData
+  const isLoading = type === 'following' ? followingLoading : followersLoading
+  const title = type === 'following' ? '팔로잉' : '팔로워'
+
+  function handleUserClick(username: string) {
+    onClose()
+    navigate(`/${username}`)
+  }
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <button onClick={onClose} className={styles.closeButton}>
+            &times;
+          </button>
+          <span className={styles.title}>{title}</span>
+        </div>
+
+        {isLoading ? (
+          <p className={styles.loading}>불러오는 중...</p>
+        ) : !data || data.users.length === 0 ? (
+          <p className={styles.empty}>
+            {type === 'following'
+              ? '아직 팔로우하는 사용자가 없습니다.'
+              : '아직 팔로워가 없습니다.'}
+          </p>
+        ) : (
+          <div className={styles.list}>
+            {data.users.map((user) => (
+              <div
+                key={user.id}
+                className={styles.userItem}
+                onClick={() => handleUserClick(user.username)}
+              >
+                {user.profileImageUrl ? (
+                  <img
+                    src={user.profileImageUrl}
+                    alt={user.displayName}
+                    className={styles.avatar}
+                  />
+                ) : (
+                  <div className={styles.avatar} />
+                )}
+                <div className={styles.userInfo}>
+                  <div className={styles.displayName}>{user.displayName}</div>
+                  <div className={styles.handle}>@{user.username}</div>
+                  {user.bio && <p className={styles.bio}>{user.bio}</p>}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useFollow.ts
+++ b/frontend/src/hooks/useFollow.ts
@@ -1,0 +1,78 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import type {
+  APIResponse,
+  FollowListResponse,
+  FollowStatusResponse,
+} from '@/types/api'
+
+async function postFollow(handle: string): Promise<FollowStatusResponse> {
+  const res = await fetch(`/api/users/${handle}/follow`, { method: 'POST' })
+  const json: APIResponse<FollowStatusResponse> = await res.json()
+  if (!json.success) {
+    throw new Error(json.error ?? 'Failed to follow')
+  }
+  return json.data
+}
+
+async function deleteFollow(handle: string): Promise<FollowStatusResponse> {
+  const res = await fetch(`/api/users/${handle}/follow`, { method: 'DELETE' })
+  const json: APIResponse<FollowStatusResponse> = await res.json()
+  if (!json.success) {
+    throw new Error(json.error ?? 'Failed to unfollow')
+  }
+  return json.data
+}
+
+async function fetchFollowing(handle: string): Promise<FollowListResponse> {
+  const res = await fetch(`/api/users/${handle}/following`)
+  const json: APIResponse<FollowListResponse> = await res.json()
+  if (!json.success) {
+    throw new Error(json.error ?? 'Failed to fetch following')
+  }
+  return json.data
+}
+
+async function fetchFollowers(handle: string): Promise<FollowListResponse> {
+  const res = await fetch(`/api/users/${handle}/followers`)
+  const json: APIResponse<FollowListResponse> = await res.json()
+  if (!json.success) {
+    throw new Error(json.error ?? 'Failed to fetch followers')
+  }
+  return json.data
+}
+
+export function useFollow(handle: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => postFollow(handle),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users', handle] })
+    },
+  })
+}
+
+export function useUnfollow(handle: string) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () => deleteFollow(handle),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users', handle] })
+    },
+  })
+}
+
+export function useFollowing(handle: string, enabled: boolean) {
+  return useQuery({
+    queryKey: ['users', handle, 'following'],
+    queryFn: () => fetchFollowing(handle),
+    enabled,
+  })
+}
+
+export function useFollowers(handle: string, enabled: boolean) {
+  return useQuery({
+    queryKey: ['users', handle, 'followers'],
+    queryFn: () => fetchFollowers(handle),
+    enabled,
+  })
+}

--- a/frontend/src/pages/ProfilePage.module.css
+++ b/frontend/src/pages/ProfilePage.module.css
@@ -81,6 +81,61 @@
   background: rgba(239, 243, 244, 0.1);
 }
 
+.followButton {
+  margin-top: 48px;
+  padding: 6px 16px;
+  border: none;
+  border-radius: 9999px;
+  background: #e7e9ea;
+  color: #0f1419;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s;
+  min-width: 100px;
+}
+
+.followButton:hover {
+  background: #d7dbdc;
+}
+
+.followButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.followingButton {
+  margin-top: 48px;
+  padding: 6px 16px;
+  border: 1px solid #536471;
+  border-radius: 9999px;
+  background: transparent;
+  color: #e7e9ea;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 100px;
+}
+
+.unfollowButton {
+  margin-top: 48px;
+  padding: 6px 16px;
+  border: 1px solid #67070f;
+  border-radius: 9999px;
+  background: transparent;
+  color: #f4212e;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 100px;
+}
+
+.unfollowButton:hover {
+  background: rgba(244, 33, 46, 0.1);
+}
+
 .profileInfo {
   margin-top: 12px;
   padding-bottom: 16px;
@@ -108,6 +163,27 @@
   margin-top: 12px;
   color: #71767b;
   font-size: 14px;
+}
+
+.followStats {
+  display: flex;
+  gap: 20px;
+  margin-top: 12px;
+}
+
+.followCount {
+  color: #71767b;
+  font-size: 14px;
+  cursor: pointer;
+  transition: text-decoration 0.2s;
+}
+
+.followCount:hover {
+  text-decoration: underline;
+}
+
+.followCount strong {
+  color: #e7e9ea;
 }
 
 .loading {

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useProfile } from '@/hooks/useProfile'
 import { useAuth } from '@/hooks/useAuthContext'
+import { useFollow, useUnfollow } from '@/hooks/useFollow'
 import EditProfileModal from '@/components/EditProfileModal'
+import FollowListModal from '@/components/FollowListModal'
 import styles from './ProfilePage.module.css'
 
 export default function ProfilePage() {
@@ -11,6 +13,13 @@ export default function ProfilePage() {
   const { user: currentUser } = useAuth()
   const { data: profile, isLoading, error } = useProfile(handle ?? '')
   const [showEditModal, setShowEditModal] = useState(false)
+  const [followListType, setFollowListType] = useState<
+    'followers' | 'following' | null
+  >(null)
+  const [isHoveringFollow, setIsHoveringFollow] = useState(false)
+
+  const follow = useFollow(handle ?? '')
+  const unfollow = useUnfollow(handle ?? '')
 
   const isOwner = currentUser?.username === profile?.username
 
@@ -43,6 +52,14 @@ export default function ProfilePage() {
     month: 'long',
   })
 
+  function handleFollowClick() {
+    if (profile?.isFollowing) {
+      unfollow.mutate()
+    } else {
+      follow.mutate()
+    }
+  }
+
   return (
     <div className={styles.container}>
       <header className={styles.backHeader}>
@@ -73,14 +90,34 @@ export default function ProfilePage() {
           ) : (
             <div className={styles.avatar} />
           )}
-          {isOwner && (
+          {isOwner ? (
             <button
               onClick={() => setShowEditModal(true)}
               className={styles.editButton}
             >
               프로필 수정
             </button>
-          )}
+          ) : currentUser ? (
+            <button
+              onClick={handleFollowClick}
+              onMouseEnter={() => setIsHoveringFollow(true)}
+              onMouseLeave={() => setIsHoveringFollow(false)}
+              className={
+                profile.isFollowing
+                  ? isHoveringFollow
+                    ? styles.unfollowButton
+                    : styles.followingButton
+                  : styles.followButton
+              }
+              disabled={follow.isPending || unfollow.isPending}
+            >
+              {profile.isFollowing
+                ? isHoveringFollow
+                  ? '언팔로우'
+                  : '팔로잉'
+                : '팔로우'}
+            </button>
+          ) : null}
         </div>
 
         <div className={styles.profileInfo}>
@@ -88,6 +125,20 @@ export default function ProfilePage() {
           <div className={styles.handle}>@{profile.username}</div>
           {profile.bio && <p className={styles.bio}>{profile.bio}</p>}
           <div className={styles.joinedDate}>{joinedDate} 가입</div>
+          <div className={styles.followStats}>
+            <span
+              className={styles.followCount}
+              onClick={() => setFollowListType('following')}
+            >
+              <strong>{profile.followingCount}</strong> 팔로잉
+            </span>
+            <span
+              className={styles.followCount}
+              onClick={() => setFollowListType('followers')}
+            >
+              <strong>{profile.followersCount}</strong> 팔로워
+            </span>
+          </div>
         </div>
       </div>
 
@@ -95,6 +146,14 @@ export default function ProfilePage() {
         <EditProfileModal
           user={currentUser}
           onClose={() => setShowEditModal(false)}
+        />
+      )}
+
+      {followListType && handle && (
+        <FollowListModal
+          handle={handle}
+          type={followListType}
+          onClose={() => setFollowListType(null)}
         />
       )}
     </div>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -32,8 +32,28 @@ export interface ProfileUser {
   bio: string
   profileImageUrl: string
   headerImageUrl: string
+  followersCount: number
+  followingCount: number
+  isFollowing: boolean
   createdAt: string
   updatedAt: string
+}
+
+export interface FollowUser {
+  id: string
+  username: string
+  displayName: string
+  bio: string
+  profileImageUrl: string
+}
+
+export interface FollowListResponse {
+  users: FollowUser[]
+  total: number
+}
+
+export interface FollowStatusResponse {
+  following: boolean
 }
 
 export interface RegisterRequest {


### PR DESCRIPTION
## Summary
- 단방향 N:M 팔로우 관계 DB 설계 및 마이그레이션 (follower_id, following_id 인덱스 포함)
- 팔로우 토글 API (`POST /api/users/:handle/follow`), 언팔로우 API (`DELETE /api/users/:handle/follow`) 구현
- 팔로잉 목록 (`GET /api/users/:handle/following`), 팔로워 목록 (`GET /api/users/:handle/followers`) 조회 API 구현
- 프론트엔드: 프로필 페이지에서 팔로우 상태에 따른 동적 버튼 렌더링, 팔로워/팔로잉 카운트 및 리스트 모달

## Changes

### Backend
- `migrations/004_create_follows` — follows 매핑 테이블 생성 (follower_id, following_id, created_at, UNIQUE 제약, 인덱스)
- `model/follow.go` — Follow 모델 정의
- `dto/follow_dto.go` — 팔로우 요청/응답 DTO
- `FollowRepository` — Create, Delete, FindFollowers, FindFollowing, Exists, CountFollowers, CountFollowing
- `FollowService` — 팔로우/언팔로우 토글, 자기 자신 팔로우 예외 처리, 목록 조회
- `FollowHandler` — Follow, Unfollow, GetFollowers, GetFollowing 핸들러
- `follow_service_test.go` — 자기 자신 팔로우 예외, 팔로우/언팔로우 로직 등 단위 테스트

### Frontend
- `useFollow` — 팔로우/언팔로우 mutation, 팔로워·팔로잉 목록 query 커스텀 훅
- `FollowListModal` — 팔로워/팔로잉 유저 리스트 모달 (프로필 네비게이션 포함)
- `ProfilePage` — 팔로우/언팔로우 버튼, 팔로워·팔로잉 카운트 표시, 모달 연동

## Test plan
- [x] `go build ./...` 통과
- [x] `go test ./...` 통과 (팔로우 서비스 테스트 포함)
- [x] `bun run build` 통과
- [x] 다른 유저 프로필 → [팔로우] 클릭 → 버튼이 [언팔로우]로 변경, 팔로워 카운트 +1
- [x] [언팔로우] 클릭 → 버튼이 [팔로우]로 변경, 팔로워 카운트 -1
- [x] 자기 자신 팔로우 시도 → 에러 응답 확인
- [x] 팔로워/팔로잉 숫자 클릭 → 모달에 유저 리스트 표시 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)