### PR TITLE
feat: implement like/unlike system with optimistic UI updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,55 +2,49 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## 프로젝트 개요
+## Project Overview
 
-트위터 클론 모노레포 프로젝트. 프론트엔드와 백엔드가 하나의 저장소에 존재합니다.
+A full-stack X (Twitter) clone monorepo. 
+**Core flow**: User Auth (JWT) → Feed (Cursor Pagination) → Interactions (Likes/Reposts) → Real-time Notifications (WebSocket).
 
-## 프로젝트 구조
+## Build & Development Commands
 
-```
-├── frontend/          # React + TypeScript (Vite)
-├── backend/           # Go + Fiber v2
-├── docker-compose.yml # Docker Compose 개발 환경
-├── INSTRUCTIONS.md    # 코딩 컨벤션 및 규칙
-├── CLAUDE.md          # Claude Code 가이드
-└── .claudeignore      # Claude Code 무시 파일
-```
-
-## 빌드 & 실행 명령어
-
-### 프론트엔드
 ```bash
+# Frontend (Requires `bun` - NEVER use npm/yarn)
 cd frontend
-bun install          # 의존성 설치
-bun run dev          # 개발 서버 (Vite)
-bun run build        # 프로덕션 빌드
-bun run preview      # 빌드 결과 미리보기
-```
+bun run dev          # Start Vite dev server
+bun run check        # Typecheck & Lint
 
-### 백엔드
-```bash
+# Backend
 cd backend
-go build ./...       # 빌드
-go run main.go       # 실행
-go test ./...        # 테스트
+go run main.go       # Start Fiber server
+go test ./...        # Run tests
+
 ```
 
-### Docker Compose (개발 환경)
-```bash
-docker compose up --build    # 전체 서비스 빌드 및 실행
-docker compose up -d         # 백그라운드 실행
-docker compose down          # 서비스 중지
-```
+## Architecture & Conventions
 
-## 아키텍처
+### Frontend (`frontend/`)
 
-- **프론트엔드**: Vite + React 19 + TypeScript. 서버 상태는 React Query, API 호출은 커스텀 hooks로 분리.
-- **백엔드**: Go + Fiber v2. handler → service → repository 레이어드 아키텍처. 인터페이스 기반 의존성 주입.
-- **데이터베이스**: PostgreSQL. 마이그레이션은 `backend/migrations/`에서 관리.
+* React 19, TypeScript, Vite, Tailwind CSS, shadcn/ui.
+* Server state via React Query. API calls MUST be separated into custom hooks.
+* Use Functional Components (PascalCase) only.
 
-## 규칙
+### Backend (`backend/`)
 
-- 코드 작성 전 반드시 INSTRUCTIONS.md의 컨벤션을 따를 것
-- 계획 모드에서 먼저 설계 후, 사용자 승인을 받고 구현
-- Conventional Commits 사용
+* **Layered Architecture**: `handler` -> `service` -> `repository`. All communication MUST use Go interfaces.
+* **Interfaces (Uber)**: NEVER use pointers to interfaces (e.g., avoid `*MyInterface`). Use the interface directly.
+* **Context First**: `ctx context.Context` MUST always be the first parameter in all function signatures.
+* **Parameter Order**: `ctx` -> clients/interfaces -> heavy types (slices/maps) -> light types (strings, bools).
+* **Error Handling**: NEVER use `panic`. Use `fmt.Errorf("failed to do X: %w", err)` for error wrapping. Define Sentinel Errors (e.g., `ErrNotFound`) at the top of the package.
+* **Dependency Injection**: Inject side effects (e.g., `time.Now()`, `rand.Int()`) from outside to ensure pure testability. Avoid `init()` functions (Uber).
+* **Concurrency**: Embed `sync.Mutex` by value (not pointer) inside structs, and always pass the struct by pointer.
+* **Slice Initialization**: Use `var s []string` for empty slices, NOT `s := make([]string, 0)`. If length is known, explicitly allocate using `make([]T, len, cap)`.
+* **Avoid Map Loops**: Do NOT loop over maps if deterministic order is required (prevents flaky tests).
+* **Naming Rules**: Use `get` for singular, `list` for plural. Do NOT use ambiguous terms like `info` or `details`.
+
+## AI Directives (CRITICAL)
+
+1. **Plan Mode**: Always output a numbered plan and wait for user approval before writing code.
+2. **Token Efficiency**: Explicitly remind the user to run `/clear` after successfully completing a task.
+3. **ReBAC**: Service layer must explicitly verify user relationships (followers, blocks) before returning resources.

--- a/backend/internal/dto/like_dto.go
+++ b/backend/internal/dto/like_dto.go
@@ -1,0 +1,5 @@
+package dto
+
+type LikeStatusResponse struct {
+	Liked bool `json:"liked"`
+}

--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -30,6 +30,8 @@ type PostDetailResponse struct {
 	Content    string     `json:"content"`
 	Visibility string     `json:"visibility"`
 	Author     PostAuthor `json:"author"`
+	LikeCount  int        `json:"likeCount"`
+	IsLiked    bool       `json:"isLiked"`
 	CreatedAt  string     `json:"createdAt"`
 	UpdatedAt  string     `json:"updatedAt"`
 }
@@ -56,6 +58,8 @@ func ToPostDetailResponse(p model.PostWithAuthor) PostDetailResponse {
 			DisplayName:     p.AuthorDisplayName,
 			ProfileImageURL: p.AuthorProfileImageURL,
 		},
+		LikeCount: p.LikeCount,
+		IsLiked:   p.IsLiked,
 		CreatedAt: p.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt: p.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 	}

--- a/backend/internal/handler/like_handler.go
+++ b/backend/internal/handler/like_handler.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/service"
+)
+
+type LikeHandler struct {
+	likeService service.LikeService
+}
+
+func NewLikeHandler(ls service.LikeService) *LikeHandler {
+	return &LikeHandler{likeService: ls}
+}
+
+func (h *LikeHandler) Like(c *fiber.Ctx) error {
+	userIDStr, ok := c.Locals("userID").(string)
+	if !ok {
+		return respondError(c, apperror.Unauthorized("not authenticated"))
+	}
+
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return respondError(c, apperror.Unauthorized("invalid user ID"))
+	}
+
+	postID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return respondError(c, apperror.BadRequest("invalid post ID"))
+	}
+
+	resp, err := h.likeService.Like(c.Context(), userID, postID)
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    resp,
+	})
+}
+
+func (h *LikeHandler) Unlike(c *fiber.Ctx) error {
+	userIDStr, ok := c.Locals("userID").(string)
+	if !ok {
+		return respondError(c, apperror.Unauthorized("not authenticated"))
+	}
+
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return respondError(c, apperror.Unauthorized("invalid user ID"))
+	}
+
+	postID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return respondError(c, apperror.BadRequest("invalid post ID"))
+	}
+
+	resp, err := h.likeService.Unlike(c.Context(), userID, postID)
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    resp,
+	})
+}

--- a/backend/internal/handler/post_handler.go
+++ b/backend/internal/handler/post_handler.go
@@ -50,7 +50,9 @@ func (h *PostHandler) GetPostByID(c *fiber.Ctx) error {
 		return respondError(c, apperror.BadRequest("invalid post ID"))
 	}
 
-	resp, err := h.postService.GetPostByID(c.Context(), id)
+	userID := extractOptionalUserID(c)
+
+	resp, err := h.postService.GetPostByID(c.Context(), id, userID)
 	if err != nil {
 		return respondError(c, err)
 	}
@@ -62,7 +64,9 @@ func (h *PostHandler) GetPostByID(c *fiber.Ctx) error {
 }
 
 func (h *PostHandler) GetPosts(c *fiber.Ctx) error {
-	posts, err := h.postService.GetPosts(c.Context())
+	userID := extractOptionalUserID(c)
+
+	posts, err := h.postService.GetPosts(c.Context(), userID)
 	if err != nil {
 		return respondError(c, err)
 	}
@@ -71,4 +75,16 @@ func (h *PostHandler) GetPosts(c *fiber.Ctx) error {
 		Success: true,
 		Data:    posts,
 	})
+}
+
+func extractOptionalUserID(c *fiber.Ctx) *uuid.UUID {
+	userIDStr, ok := c.Locals("userID").(string)
+	if !ok {
+		return nil
+	}
+	id, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return nil
+	}
+	return &id
 }

--- a/backend/internal/model/like.go
+++ b/backend/internal/model/like.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Like struct {
+	UserID    uuid.UUID
+	PostID    uuid.UUID
+	CreatedAt time.Time
+}

--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -19,6 +19,7 @@ type Post struct {
 	AuthorID   uuid.UUID
 	Content    string
 	Visibility Visibility
+	LikeCount  int
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }
@@ -26,6 +27,7 @@ type Post struct {
 type PostWithAuthor struct {
 	Post
 	AuthorUsername        string
-	AuthorDisplayName    string
+	AuthorDisplayName     string
 	AuthorProfileImageURL string
+	IsLiked               bool
 }

--- a/backend/internal/repository/like_repository.go
+++ b/backend/internal/repository/like_repository.go
@@ -1,0 +1,89 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type LikeRepository interface {
+	Like(ctx context.Context, userID, postID uuid.UUID) error
+	Unlike(ctx context.Context, userID, postID uuid.UUID) error
+	IsLiked(ctx context.Context, userID, postID uuid.UUID) (bool, error)
+}
+
+type likeRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewLikeRepository(pool *pgxpool.Pool) LikeRepository {
+	return &likeRepository{pool: pool}
+}
+
+func (r *likeRepository) Like(ctx context.Context, userID, postID uuid.UUID) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx,
+		`INSERT INTO likes (user_id, post_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+		userID, postID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to insert like: %w", err)
+	}
+
+	_, err = tx.Exec(ctx,
+		`UPDATE posts SET like_count = like_count + 1 WHERE id = $1`,
+		postID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update like_count: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (r *likeRepository) Unlike(ctx context.Context, userID, postID uuid.UUID) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	tag, err := tx.Exec(ctx,
+		`DELETE FROM likes WHERE user_id = $1 AND post_id = $2`,
+		userID, postID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to delete like: %w", err)
+	}
+
+	if tag.RowsAffected() > 0 {
+		_, err = tx.Exec(ctx,
+			`UPDATE posts SET like_count = like_count - 1 WHERE id = $1`,
+			postID,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to update like_count: %w", err)
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (r *likeRepository) IsLiked(ctx context.Context, userID, postID uuid.UUID) (bool, error) {
+	var exists bool
+	err := r.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM likes WHERE user_id = $1 AND post_id = $2)`,
+		userID, postID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to check like status: %w", err)
+	}
+	return exists, nil
+}

--- a/backend/internal/repository/post_repository.go
+++ b/backend/internal/repository/post_repository.go
@@ -12,6 +12,8 @@ type PostRepository interface {
 	Create(ctx context.Context, post *model.Post) error
 	FindByID(ctx context.Context, id uuid.UUID) (*model.PostWithAuthor, error)
 	FindAll(ctx context.Context, limit, offset int) ([]model.PostWithAuthor, error)
+	FindByIDWithUser(ctx context.Context, id, userID uuid.UUID) (*model.PostWithAuthor, error)
+	FindAllWithUser(ctx context.Context, limit, offset int, userID uuid.UUID) ([]model.PostWithAuthor, error)
 }
 
 type postRepository struct {
@@ -36,7 +38,7 @@ func (r *postRepository) Create(ctx context.Context, post *model.Post) error {
 func (r *postRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.PostWithAuthor, error) {
 	p := &model.PostWithAuthor{}
 	query := `
-		SELECT p.id, p.author_id, p.content, p.visibility, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.content, p.visibility, p.like_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url
 		FROM posts p
 		JOIN users u ON p.author_id = u.id
@@ -44,7 +46,7 @@ func (r *postRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.Pos
 
 	var visibility string
 	err := r.pool.QueryRow(ctx, query, id).Scan(
-		&p.ID, &p.AuthorID, &p.Content, &visibility, &p.CreatedAt, &p.UpdatedAt,
+		&p.ID, &p.AuthorID, &p.Content, &visibility, &p.LikeCount, &p.CreatedAt, &p.UpdatedAt,
 		&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
 	)
 	if err != nil {
@@ -56,7 +58,7 @@ func (r *postRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.Pos
 
 func (r *postRepository) FindAll(ctx context.Context, limit, offset int) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.content, p.visibility, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.content, p.visibility, p.like_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url
 		FROM posts p
 		JOIN users u ON p.author_id = u.id
@@ -74,8 +76,64 @@ func (r *postRepository) FindAll(ctx context.Context, limit, offset int) ([]mode
 		var p model.PostWithAuthor
 		var visibility string
 		if err := rows.Scan(
-			&p.ID, &p.AuthorID, &p.Content, &visibility, &p.CreatedAt, &p.UpdatedAt,
+			&p.ID, &p.AuthorID, &p.Content, &visibility, &p.LikeCount, &p.CreatedAt, &p.UpdatedAt,
 			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
+		); err != nil {
+			return nil, err
+		}
+		p.Visibility = model.Visibility(visibility)
+		posts = append(posts, p)
+	}
+	return posts, rows.Err()
+}
+
+func (r *postRepository) FindByIDWithUser(ctx context.Context, id, userID uuid.UUID) (*model.PostWithAuthor, error) {
+	p := &model.PostWithAuthor{}
+	query := `
+		SELECT p.id, p.author_id, p.content, p.visibility, p.like_count, p.created_at, p.updated_at,
+		       u.username, u.display_name, u.profile_image_url,
+		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $2 AND l.post_id = p.id) AS is_liked
+		FROM posts p
+		JOIN users u ON p.author_id = u.id
+		WHERE p.id = $1`
+
+	var visibility string
+	err := r.pool.QueryRow(ctx, query, id, userID).Scan(
+		&p.ID, &p.AuthorID, &p.Content, &visibility, &p.LikeCount, &p.CreatedAt, &p.UpdatedAt,
+		&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
+		&p.IsLiked,
+	)
+	if err != nil {
+		return nil, err
+	}
+	p.Visibility = model.Visibility(visibility)
+	return p, nil
+}
+
+func (r *postRepository) FindAllWithUser(ctx context.Context, limit, offset int, userID uuid.UUID) ([]model.PostWithAuthor, error) {
+	query := `
+		SELECT p.id, p.author_id, p.content, p.visibility, p.like_count, p.created_at, p.updated_at,
+		       u.username, u.display_name, u.profile_image_url,
+		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $3 AND l.post_id = p.id) AS is_liked
+		FROM posts p
+		JOIN users u ON p.author_id = u.id
+		ORDER BY p.created_at DESC
+		LIMIT $1 OFFSET $2`
+
+	rows, err := r.pool.Query(ctx, query, limit, offset, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var posts []model.PostWithAuthor
+	for rows.Next() {
+		var p model.PostWithAuthor
+		var visibility string
+		if err := rows.Scan(
+			&p.ID, &p.AuthorID, &p.Content, &visibility, &p.LikeCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
+			&p.IsLiked,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/internal/service/like_service.go
+++ b/backend/internal/service/like_service.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/repository"
+)
+
+type LikeService interface {
+	Like(ctx context.Context, userID, postID uuid.UUID) (*dto.LikeStatusResponse, error)
+	Unlike(ctx context.Context, userID, postID uuid.UUID) (*dto.LikeStatusResponse, error)
+}
+
+type likeService struct {
+	likeRepo repository.LikeRepository
+	postRepo repository.PostRepository
+}
+
+func NewLikeService(likeRepo repository.LikeRepository, postRepo repository.PostRepository) LikeService {
+	return &likeService{likeRepo: likeRepo, postRepo: postRepo}
+}
+
+func (s *likeService) Like(ctx context.Context, userID, postID uuid.UUID) (*dto.LikeStatusResponse, error) {
+	_, err := s.postRepo.FindByID(ctx, postID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, apperror.NotFound("post not found")
+		}
+		return nil, apperror.Internal("failed to find post")
+	}
+
+	liked, err := s.likeRepo.IsLiked(ctx, userID, postID)
+	if err != nil {
+		return nil, apperror.Internal("failed to check like status")
+	}
+	if liked {
+		return nil, apperror.Conflict("already liked")
+	}
+
+	if err := s.likeRepo.Like(ctx, userID, postID); err != nil {
+		return nil, apperror.Internal("failed to like post")
+	}
+
+	return &dto.LikeStatusResponse{Liked: true}, nil
+}
+
+func (s *likeService) Unlike(ctx context.Context, userID, postID uuid.UUID) (*dto.LikeStatusResponse, error) {
+	_, err := s.postRepo.FindByID(ctx, postID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, apperror.NotFound("post not found")
+		}
+		return nil, apperror.Internal("failed to find post")
+	}
+
+	liked, err := s.likeRepo.IsLiked(ctx, userID, postID)
+	if err != nil {
+		return nil, apperror.Internal("failed to check like status")
+	}
+	if !liked {
+		return nil, apperror.Conflict("not liked yet")
+	}
+
+	if err := s.likeRepo.Unlike(ctx, userID, postID); err != nil {
+		return nil, apperror.Internal("failed to unlike post")
+	}
+
+	return &dto.LikeStatusResponse{Liked: false}, nil
+}

--- a/backend/internal/service/post_service.go
+++ b/backend/internal/service/post_service.go
@@ -14,8 +14,8 @@ import (
 
 type PostService interface {
 	CreatePost(ctx context.Context, authorID uuid.UUID, req dto.CreatePostRequest) (*dto.PostDetailResponse, error)
-	GetPostByID(ctx context.Context, id uuid.UUID) (*dto.PostDetailResponse, error)
-	GetPosts(ctx context.Context) ([]dto.PostDetailResponse, error)
+	GetPostByID(ctx context.Context, id uuid.UUID, userID *uuid.UUID) (*dto.PostDetailResponse, error)
+	GetPosts(ctx context.Context, userID *uuid.UUID) ([]dto.PostDetailResponse, error)
 }
 
 type postService struct {
@@ -64,8 +64,16 @@ func (s *postService) CreatePost(ctx context.Context, authorID uuid.UUID, req dt
 	return &resp, nil
 }
 
-func (s *postService) GetPostByID(ctx context.Context, id uuid.UUID) (*dto.PostDetailResponse, error) {
-	result, err := s.postRepo.FindByID(ctx, id)
+func (s *postService) GetPostByID(ctx context.Context, id uuid.UUID, userID *uuid.UUID) (*dto.PostDetailResponse, error) {
+	var result *model.PostWithAuthor
+	var err error
+
+	if userID != nil {
+		result, err = s.postRepo.FindByIDWithUser(ctx, id, *userID)
+	} else {
+		result, err = s.postRepo.FindByID(ctx, id)
+	}
+
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return nil, apperror.NotFound("post not found")
@@ -77,8 +85,16 @@ func (s *postService) GetPostByID(ctx context.Context, id uuid.UUID) (*dto.PostD
 	return &resp, nil
 }
 
-func (s *postService) GetPosts(ctx context.Context) ([]dto.PostDetailResponse, error) {
-	posts, err := s.postRepo.FindAll(ctx, 50, 0)
+func (s *postService) GetPosts(ctx context.Context, userID *uuid.UUID) ([]dto.PostDetailResponse, error) {
+	var posts []model.PostWithAuthor
+	var err error
+
+	if userID != nil {
+		posts, err = s.postRepo.FindAllWithUser(ctx, 50, 0, *userID)
+	} else {
+		posts, err = s.postRepo.FindAll(ctx, 50, 0)
+	}
+
 	if err != nil {
 		return nil, apperror.Internal("failed to retrieve posts")
 	}

--- a/backend/internal/service/post_service_test.go
+++ b/backend/internal/service/post_service_test.go
@@ -48,6 +48,14 @@ func (m *mockPostRepo) FindAll(_ context.Context, _, _ int) ([]model.PostWithAut
 	return posts, nil
 }
 
+func (m *mockPostRepo) FindByIDWithUser(_ context.Context, id, _ uuid.UUID) (*model.PostWithAuthor, error) {
+	return m.FindByID(context.Background(), id)
+}
+
+func (m *mockPostRepo) FindAllWithUser(_ context.Context, limit, offset int, _ uuid.UUID) ([]model.PostWithAuthor, error) {
+	return m.FindAll(context.Background(), limit, offset)
+}
+
 func TestCreatePost_Success(t *testing.T) {
 	repo := newMockPostRepo()
 	svc := NewPostService(repo)
@@ -118,7 +126,7 @@ func TestGetPostByID_Success(t *testing.T) {
 	})
 
 	postID, _ := uuid.Parse(created.ID)
-	resp, err := svc.GetPostByID(context.Background(), postID)
+	resp, err := svc.GetPostByID(context.Background(), postID, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -131,7 +139,7 @@ func TestGetPostByID_NotFound(t *testing.T) {
 	repo := newMockPostRepo()
 	svc := NewPostService(repo)
 
-	_, err := svc.GetPostByID(context.Background(), uuid.New())
+	_, err := svc.GetPostByID(context.Background(), uuid.New(), nil)
 	if err == nil {
 		t.Fatal("expected error for nonexistent post")
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -35,6 +35,10 @@ func main() {
 	postService := service.NewPostService(postRepo)
 	postHandler := handler.NewPostHandler(postService)
 
+	likeRepo := repository.NewLikeRepository(pool)
+	likeService := service.NewLikeService(likeRepo, postRepo)
+	likeHandler := handler.NewLikeHandler(likeService)
+
 	userRepo := repository.NewUserRepository(pool)
 	authService := service.NewAuthService(userRepo, cfg.JWTSecret, cfg.JWTExpiryHours)
 	authHandler := handler.NewAuthHandler(authService)
@@ -48,9 +52,11 @@ func main() {
 
 	api := app.Group("/api")
 	posts := api.Group("/posts")
-	posts.Get("/", postHandler.GetPosts)
+	posts.Get("/", middleware.OptionalAuth(cfg.JWTSecret), postHandler.GetPosts)
 	posts.Post("/", middleware.AuthRequired(cfg.JWTSecret), postHandler.CreatePost)
-	posts.Get("/:id", postHandler.GetPostByID)
+	posts.Get("/:id", middleware.OptionalAuth(cfg.JWTSecret), postHandler.GetPostByID)
+	posts.Post("/:id/like", middleware.AuthRequired(cfg.JWTSecret), likeHandler.Like)
+	posts.Delete("/:id/like", middleware.AuthRequired(cfg.JWTSecret), likeHandler.Unlike)
 
 	auth := api.Group("/auth")
 	auth.Post("/register", authHandler.Register)

--- a/backend/migrations/005_create_likes.down.sql
+++ b/backend/migrations/005_create_likes.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE posts DROP COLUMN IF EXISTS like_count;
+
+DROP TABLE IF EXISTS likes;

--- a/backend/migrations/005_create_likes.up.sql
+++ b/backend/migrations/005_create_likes.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE likes (
+    user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    post_id    UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, post_id)
+);
+
+CREATE INDEX idx_likes_post_id ON likes(post_id);
+
+ALTER TABLE posts ADD COLUMN like_count INT NOT NULL DEFAULT 0;

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { Heart } from 'lucide-react'
 import type { PostDetail } from '@/types/api'
 import { useAuth } from '@/hooks/useAuthContext'
 import { useProfile } from '@/hooks/useProfile'
 import { useFollow, useUnfollow } from '@/hooks/useFollow'
+import { useLike } from '@/hooks/useLike'
 import ProfileHoverCard from '@/components/ProfileHoverCard'
 import { cn } from '@/lib/utils'
 
@@ -32,6 +34,7 @@ function PostCard({ post }: PostCardProps) {
   const { data: authorProfile } = useProfile(post.author.username, !isOwner)
   const follow = useFollow(post.author.username)
   const unfollow = useUnfollow(post.author.username)
+  const like = useLike(post.id, post.isLiked)
 
   function handleFollowClick(e: React.MouseEvent) {
     e.stopPropagation()
@@ -40,6 +43,12 @@ function PostCard({ post }: PostCardProps) {
     } else {
       follow.mutate()
     }
+  }
+
+  function handleLikeClick(e: React.MouseEvent) {
+    e.stopPropagation()
+    if (!currentUser) return
+    like.mutate()
   }
 
   return (
@@ -118,9 +127,31 @@ function PostCard({ post }: PostCardProps) {
         </div>
       </div>
       <p className="mb-2 text-[15px] leading-normal text-foreground">{post.content}</p>
-      <span className="text-[13px] text-muted-foreground">
-        {new Date(post.createdAt).toLocaleString()}
-      </span>
+      <div className="flex items-center gap-4">
+        <span className="text-[13px] text-muted-foreground">
+          {new Date(post.createdAt).toLocaleString()}
+        </span>
+        <button
+          onClick={handleLikeClick}
+          className="group flex cursor-pointer items-center gap-1 border-none bg-transparent p-0"
+        >
+          <Heart
+            size={16}
+            className={cn(
+              'transition-colors group-hover:text-red-500',
+              post.isLiked ? 'fill-red-500 text-red-500' : 'text-muted-foreground',
+            )}
+          />
+          <span
+            className={cn(
+              'text-[13px] transition-colors group-hover:text-red-500',
+              post.isLiked ? 'text-red-500' : 'text-muted-foreground',
+            )}
+          >
+            {post.likeCount}
+          </span>
+        </button>
+      </div>
     </div>
   )
 }

--- a/frontend/src/hooks/useLike.ts
+++ b/frontend/src/hooks/useLike.ts
@@ -1,0 +1,73 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { APIResponse, LikeStatusResponse, PostDetail } from '@/types/api'
+
+async function postLike(postId: string): Promise<LikeStatusResponse> {
+  const res = await fetch(`/api/posts/${postId}/like`, { method: 'POST' })
+  const json: APIResponse<LikeStatusResponse> = await res.json()
+  if (!json.success) {
+    throw new Error(json.error ?? 'Failed to like')
+  }
+  return json.data
+}
+
+async function deleteLike(postId: string): Promise<LikeStatusResponse> {
+  const res = await fetch(`/api/posts/${postId}/like`, { method: 'DELETE' })
+  const json: APIResponse<LikeStatusResponse> = await res.json()
+  if (!json.success) {
+    throw new Error(json.error ?? 'Failed to unlike')
+  }
+  return json.data
+}
+
+function updatePostInCache(old: PostDetail, liked: boolean): PostDetail {
+  return {
+    ...old,
+    isLiked: liked,
+    likeCount: old.likeCount + (liked ? 1 : -1),
+  }
+}
+
+export function useLike(postId: string, isLiked: boolean) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => (isLiked ? deleteLike(postId) : postLike(postId)),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ['posts'] })
+      await queryClient.cancelQueries({ queryKey: ['post', postId] })
+
+      const prevPosts = queryClient.getQueryData<PostDetail[]>(['posts'])
+      const prevPost = queryClient.getQueryData<PostDetail>(['post', postId])
+
+      const nextLiked = !isLiked
+
+      if (prevPosts) {
+        queryClient.setQueryData<PostDetail[]>(['posts'], (old) =>
+          old?.map((p) =>
+            p.id === postId ? updatePostInCache(p, nextLiked) : p,
+          ),
+        )
+      }
+
+      if (prevPost) {
+        queryClient.setQueryData<PostDetail>(['post', postId], (old) =>
+          old ? updatePostInCache(old, nextLiked) : old,
+        )
+      }
+
+      return { prevPosts, prevPost }
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prevPosts) {
+        queryClient.setQueryData(['posts'], context.prevPosts)
+      }
+      if (context?.prevPost) {
+        queryClient.setQueryData(['post', postId], context.prevPost)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['posts'] })
+      queryClient.invalidateQueries({ queryKey: ['post', postId] })
+    },
+  })
+}

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
+import { Heart } from 'lucide-react'
 import { usePostDetail } from '@/hooks/usePosts'
 import { useAuth } from '@/hooks/useAuthContext'
 import { useProfile } from '@/hooks/useProfile'
 import { useFollow, useUnfollow } from '@/hooks/useFollow'
+import { useLike } from '@/hooks/useLike'
 import ProfileHoverCard from '@/components/ProfileHoverCard'
 import { cn } from '@/lib/utils'
 
@@ -19,6 +21,7 @@ export default function PostDetailPage() {
   const { data: authorProfile } = useProfile(authorUsername, !!post && !isOwner)
   const follow = useFollow(authorUsername)
   const unfollow = useUnfollow(authorUsername)
+  const like = useLike(id ?? '', post?.isLiked ?? false)
 
   if (isLoading) return <p className="px-4 py-8 text-center text-muted-foreground">Loading...</p>
   if (error) return <p className="px-4 py-8 text-center text-muted-foreground">Error: {error.message}</p>
@@ -30,6 +33,11 @@ export default function PostDetailPage() {
     } else {
       follow.mutate()
     }
+  }
+
+  function handleLikeClick() {
+    if (!currentUser) return
+    like.mutate()
   }
 
   return (
@@ -103,9 +111,31 @@ export default function PostDetailPage() {
           )}
         </div>
         <p className="mb-4 text-[17px] leading-relaxed text-foreground">{post.content}</p>
-        <span className="block border-t border-border pt-4 text-sm text-muted-foreground">
-          {new Date(post.createdAt).toLocaleString()}
-        </span>
+        <div className="flex items-center gap-4 border-t border-border pt-4">
+          <span className="text-sm text-muted-foreground">
+            {new Date(post.createdAt).toLocaleString()}
+          </span>
+          <button
+            onClick={handleLikeClick}
+            className="group flex cursor-pointer items-center gap-1.5 border-none bg-transparent p-0"
+          >
+            <Heart
+              size={20}
+              className={cn(
+                'transition-colors group-hover:text-red-500',
+                post.isLiked ? 'fill-red-500 text-red-500' : 'text-muted-foreground',
+              )}
+            />
+            <span
+              className={cn(
+                'text-sm transition-colors group-hover:text-red-500',
+                post.isLiked ? 'text-red-500' : 'text-muted-foreground',
+              )}
+            >
+              {post.likeCount}
+            </span>
+          </button>
+        </div>
       </article>
     </div>
   )

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -92,6 +92,12 @@ export interface PostDetail {
   content: string
   visibility: 'public' | 'friends' | 'private'
   author: PostAuthor
+  likeCount: number
+  isLiked: boolean
   createdAt: string
   updatedAt: string
+}
+
+export interface LikeStatusResponse {
+  liked: boolean
 }


### PR DESCRIPTION
Closes #7

## Summary
- 백엔드 좋아요 API 구현 (POST/DELETE `/api/posts/:id/like`), 트랜잭션 기반 `like_count` 동기화
- 프론트엔드 Heart 버튼 + optimistic update (`PostCard`, `PostDetailPage`)
- `OptionalAuth` 미들웨어로 로그인 유저의 좋아요 상태 반영

## Test plan
- [ ] 로그인 후 다른 사용자의 게시글에서 좋아요/좋아요 취소 동작 확인
- [ ] PostCard 및 PostDetailPage에서 좋아요 수 실시간 반영 확인
- [ ] 비로그인 상태에서 좋아요 버튼 클릭 시 무반응 확인
- [ ] `go test ./...` 백엔드 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)