### PR TITLE
feat: enhance main UI layout and styling for key pages (#19)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,7 +35,20 @@
 - [x] ComponentShowcasePage (/dev/components)
 - [x] orphan .module.css 파일 정리 (#18)
 
+## Phase 6: UI 레이아웃 고도화 (완료)
+- [x] MainLayout 3단 레이아웃 (사이드바 + 피드 + 위젯 패널)
+- [x] Sidebar 컴포넌트 (반응형: 데스크톱/태블릿/모바일)
+- [x] MobileNav 하단 네비게이션 바
+- [x] RightPanel 검색 + 트렌드 위젯
+- [x] PostCard UI 고도화 (상대시간, Repost/Share 버튼, X 스타일 레이아웃)
+- [x] ComposeForm 고도화 (원형 글자수 프로그레스, 아바타)
+- [x] ProfilePage 고도화 (탭 네비게이션, ArrowLeft 아이콘, CalendarDays)
+- [x] PostDetailPage 고도화 (액션 버튼 4종, 통계 표시)
+- [x] LoginPage/RegisterPage shadcn/ui 마이그레이션
+- [x] formatRelativeTime 유틸리티 함수
+
 ## 최근 변경 로그
+- 2026-03-06: 이슈 #19 주요 UI 레이아웃 및 스타일링 고도화 (3단 레이아웃, 반응형)
 - 2026-03-06: 이슈 #18 shadcn/ui 기반 공통 UI 컴포넌트 시스템 구축
 - 2026-03-05: 이슈 #28 Post Detail API nested replies 최적화 (110+→1 요청)
 - 2026-03-05: 이슈 #27 대댓글 depth 2 자동 펼침 + 부모 스레드 체인 표시 구현

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,18 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import { AuthProvider } from '@/contexts/AuthContext'
-import ProtectedRoute from '@/components/ProtectedRoute'
-import GuestRoute from '@/components/GuestRoute'
-import HomePage from '@/pages/HomePage'
-import LoginPage from '@/pages/LoginPage'
-import RegisterPage from '@/pages/RegisterPage'
-import ProfilePage from '@/pages/ProfilePage'
-import PostDetailPage from '@/pages/PostDetailPage'
-import OnboardingPage from '@/pages/OnboardingPage'
-import ComponentShowcasePage from '@/pages/ComponentShowcasePage'
-import { Toaster } from '@/components/ui/sonner'
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { AuthProvider } from "@/contexts/AuthContext";
+import ProtectedRoute from "@/components/ProtectedRoute";
+import GuestRoute from "@/components/GuestRoute";
+import MainLayout from "@/components/layout/MainLayout";
+import HomePage from "@/pages/HomePage";
+import LoginPage from "@/pages/LoginPage";
+import RegisterPage from "@/pages/RegisterPage";
+import ProfilePage from "@/pages/ProfilePage";
+import PostDetailPage from "@/pages/PostDetailPage";
+import OnboardingPage from "@/pages/OnboardingPage";
+import { Toaster } from "@/components/ui/sonner";
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient();
 
 function App() {
   return (
@@ -20,14 +20,7 @@ function App() {
       <BrowserRouter>
         <AuthProvider>
           <Routes>
-            <Route
-              path="/"
-              element={
-                <ProtectedRoute>
-                  <HomePage />
-                </ProtectedRoute>
-              }
-            />
+            {/* Auth pages - no layout */}
             <Route
               path="/login"
               element={
@@ -44,37 +37,26 @@ function App() {
                 </GuestRoute>
               }
             />
+
+            {/* App pages - with layout */}
             <Route
-              path="/post/:id"
               element={
                 <ProtectedRoute>
-                  <PostDetailPage />
+                  <MainLayout />
                 </ProtectedRoute>
               }
-            />
-            <Route
-              path="/onboarding"
-              element={
-                <ProtectedRoute>
-                  <OnboardingPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route path="/dev/components" element={<ComponentShowcasePage />} />
-            <Route
-              path="/:handle"
-              element={
-                <ProtectedRoute>
-                  <ProfilePage />
-                </ProtectedRoute>
-              }
-            />
+            >
+              <Route path="/" element={<HomePage />} />
+              <Route path="/post/:id" element={<PostDetailPage />} />
+              <Route path="/onboarding" element={<OnboardingPage />} />
+              <Route path="/:handle" element={<ProfilePage />} />
+            </Route>
           </Routes>
           <Toaster richColors position="bottom-right" />
         </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/ComposeForm.tsx
+++ b/frontend/src/components/ComposeForm.tsx
@@ -1,64 +1,118 @@
-import { useState } from 'react'
-import { useCreatePost } from '@/hooks/usePosts'
-import { toast } from 'sonner'
-import { Textarea } from '@/components/ui/textarea'
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
+import { useState } from "react";
+import { useCreatePost } from "@/hooks/usePosts";
+import { useAuth } from "@/hooks/useAuthContext";
+import { toast } from "sonner";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import UserAvatar from "@/components/UserAvatar";
 
-const MAX_LENGTH = 280
+const MAX_LENGTH = 280;
+const WARN_THRESHOLD = 20;
+const CIRCLE_RADIUS = 10;
+const CIRCLE_CIRCUMFERENCE = 2 * Math.PI * CIRCLE_RADIUS;
 
 export default function ComposeForm() {
-  const [content, setContent] = useState('')
-  const { mutate, isPending } = useCreatePost()
+  const [content, setContent] = useState("");
+  const { mutate, isPending } = useCreatePost();
+  const { user } = useAuth();
 
-  const remaining = MAX_LENGTH - [...content].length
+  const charCount = [...content].length;
+  const remaining = MAX_LENGTH - charCount;
+  const progress = Math.min(charCount / MAX_LENGTH, 1);
+  const strokeDashoffset = CIRCLE_CIRCUMFERENCE * (1 - progress);
+
+  const circleColor =
+    remaining < 0
+      ? "text-destructive"
+      : remaining <= WARN_THRESHOLD
+        ? "text-warning"
+        : "text-primary";
 
   function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (remaining < 0 || content.trim().length === 0 || isPending) return
+    e.preventDefault();
+    if (remaining < 0 || content.trim().length === 0 || isPending) return;
 
     mutate(
-      { content, visibility: 'public' },
+      { content, visibility: "public" },
       {
         onSuccess: () => {
-          setContent('')
-          toast.success('게시글이 작성되었습니다.')
+          setContent("");
+          toast.success("게시글이 작성되었습니다.");
         },
         onError: (err) => {
-          toast.error('게시글 작성에 실패했습니다.', { description: err.message })
+          toast.error("게시글 작성에 실패했습니다.", {
+            description: err.message,
+          });
         },
       },
-    )
+    );
   }
 
   return (
-    <form className="border-b border-border p-4" onSubmit={handleSubmit}>
-      <Textarea
-        className="w-full resize-none border-none bg-transparent py-2 text-lg shadow-none focus-visible:ring-0 placeholder:text-muted-foreground"
-        placeholder="What is happening?!"
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        maxLength={300}
-        rows={3}
+    <form
+      className="flex gap-3 border-b border-border p-4"
+      onSubmit={handleSubmit}
+    >
+      <UserAvatar
+        profileImageUrl={user?.profileImageUrl}
+        displayName={user?.displayName}
+        size="md"
+        className="mt-1 shrink-0"
       />
-      <div className="flex items-center justify-end gap-3 border-t border-border pt-2">
-        <span
-          className={cn(
-            'text-sm text-muted-foreground',
-            remaining < 0 && 'text-destructive',
-            remaining >= 0 && remaining <= 20 && 'text-warning',
+      <div className="flex-1">
+        <Textarea
+          className="w-full resize-none border-none bg-transparent py-2 text-lg shadow-none focus-visible:ring-0 placeholder:text-muted-foreground"
+          placeholder="무슨 일이 일어나고 있나요?"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          maxLength={300}
+          rows={3}
+        />
+        <div className="flex items-center justify-end gap-3 border-t border-border pt-2">
+          {charCount > 0 && (
+            <div className="flex items-center gap-1.5">
+              <svg className="h-[26px] w-[26px] -rotate-90" viewBox="0 0 24 24">
+                <circle
+                  cx="12"
+                  cy="12"
+                  r={CIRCLE_RADIUS}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  className="text-border"
+                />
+                <circle
+                  cx="12"
+                  cy="12"
+                  r={CIRCLE_RADIUS}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeDasharray={CIRCLE_CIRCUMFERENCE}
+                  strokeDashoffset={strokeDashoffset}
+                  strokeLinecap="round"
+                  className={`transition-all duration-200 ${circleColor}`}
+                />
+              </svg>
+              {remaining <= WARN_THRESHOLD && (
+                <span
+                  className={`text-[13px] font-medium ${remaining < 0 ? "text-destructive" : "text-warning"}`}
+                >
+                  {remaining}
+                </span>
+              )}
+            </div>
           )}
-        >
-          {remaining}
-        </span>
-        <Button
-          type="submit"
-          className="rounded-full"
-          disabled={remaining < 0 || content.trim().length === 0 || isPending}
-        >
-          {isPending ? 'Posting...' : 'Post'}
-        </Button>
+          <Button
+            type="submit"
+            className="rounded-full px-5"
+            size="sm"
+            disabled={remaining < 0 || content.trim().length === 0 || isPending}
+          >
+            {isPending ? "게시 중..." : "게시하기"}
+          </Button>
+        </div>
       </div>
     </form>
-  )
+  );
 }

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -1,162 +1,202 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { Heart, MessageCircle } from 'lucide-react'
-import type { PostDetail } from '@/types/api'
-import { useAuth } from '@/hooks/useAuthContext'
-import { useProfile } from '@/hooks/useProfile'
-import { useFollow, useUnfollow } from '@/hooks/useFollow'
-import { useLike } from '@/hooks/useLike'
-import ProfileHoverCard from '@/components/ProfileHoverCard'
-import UserAvatar from '@/components/UserAvatar'
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Heart, MessageCircle, Repeat2, Share } from "lucide-react";
+import type { PostDetail } from "@/types/api";
+import { useAuth } from "@/hooks/useAuthContext";
+import { useProfile } from "@/hooks/useProfile";
+import { useFollow, useUnfollow } from "@/hooks/useFollow";
+import { useLike } from "@/hooks/useLike";
+import { formatRelativeTime } from "@/lib/formatTime";
+import ProfileHoverCard from "@/components/ProfileHoverCard";
+import UserAvatar from "@/components/UserAvatar";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 interface PostCardProps {
-  post: PostDetail
-}
-
-const visibilityLabel: Record<PostDetail['visibility'], string> = {
-  public: 'Public',
-  friends: 'Friends',
-  private: 'Private',
-}
-
-const visibilityClasses: Record<PostDetail['visibility'], string> = {
-  public: 'bg-green-900/50 text-green-400',
-  friends: 'bg-blue-900/50 text-blue-400',
-  private: 'bg-red-900/50 text-red-400',
+  post: PostDetail;
 }
 
 function PostCard({ post }: PostCardProps) {
-  const navigate = useNavigate()
-  const { user: currentUser } = useAuth()
-  const [isHoveringFollow, setIsHoveringFollow] = useState(false)
+  const navigate = useNavigate();
+  const { user: currentUser } = useAuth();
+  const [isHoveringFollow, setIsHoveringFollow] = useState(false);
 
-  const isOwner = currentUser?.username === post.author.username
-  const { data: authorProfile } = useProfile(post.author.username, !isOwner)
-  const follow = useFollow(post.author.username)
-  const unfollow = useUnfollow(post.author.username)
-  const like = useLike(post.id, post.isLiked)
+  const isOwner = currentUser?.username === post.author.username;
+  const { data: authorProfile } = useProfile(post.author.username, !isOwner);
+  const follow = useFollow(post.author.username);
+  const unfollow = useUnfollow(post.author.username);
+  const like = useLike(post.id, post.isLiked);
 
   function handleFollowClick(e: React.MouseEvent) {
-    e.stopPropagation()
+    e.stopPropagation();
     if (authorProfile?.isFollowing) {
-      unfollow.mutate()
+      unfollow.mutate();
     } else {
-      follow.mutate()
+      follow.mutate();
     }
   }
 
   function handleLikeClick(e: React.MouseEvent) {
-    e.stopPropagation()
-    if (!currentUser) return
-    like.mutate()
+    e.stopPropagation();
+    if (!currentUser) return;
+    like.mutate();
   }
 
   return (
-    <div
-      className="cursor-pointer border-b border-border p-4 transition-colors hover:bg-foreground/[0.03]"
+    <article
+      className="cursor-pointer border-b border-border px-4 py-3 transition-colors hover:bg-foreground/[0.03]"
       onClick={() => navigate(`/post/${post.id}`)}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
-        if (e.key === 'Enter') navigate(`/post/${post.id}`)
+        if (e.key === "Enter") navigate(`/post/${post.id}`);
       }}
     >
-      <div className="mb-2 flex items-center justify-between">
-        <div className="flex items-center gap-2.5">
+      <div className="flex gap-3">
+        <div
+          className="mt-0.5 shrink-0 cursor-pointer"
+          onClick={(e) => {
+            e.stopPropagation()
+            navigate(`/${post.author.username}`)
+          }}
+        >
           <UserAvatar
             profileImageUrl={post.author.profileImageUrl}
             displayName={post.author.displayName || post.author.username}
             size="md"
           />
-          <div>
-            <ProfileHoverCard
-              handle={post.author.username}
-              currentUsername={currentUser?.username}
-            >
+        </div>
+        <div className="min-w-0 flex-1">
+          {/* Author Row */}
+          <div className="flex items-center justify-between">
+            <div className="flex min-w-0 items-center gap-1">
+              <ProfileHoverCard
+                handle={post.author.username}
+                currentUsername={currentUser?.username}
+              >
+                <span
+                  className="cursor-pointer truncate text-[15px] font-bold text-foreground hover:underline"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigate(`/${post.author.username}`);
+                  }}
+                >
+                  {post.author.displayName || post.author.username}
+                </span>
+              </ProfileHoverCard>
               <span
-                className="mr-1 cursor-pointer text-[15px] font-bold text-foreground hover:underline"
+                className="cursor-pointer text-[15px] text-muted-foreground hover:underline"
                 onClick={(e) => {
-                  e.stopPropagation()
-                  navigate(`/${post.author.username}`)
+                  e.stopPropagation();
+                  navigate(`/${post.author.username}`);
                 }}
               >
-                {post.author.displayName || post.author.username}
+                @{post.author.username}
               </span>
-            </ProfileHoverCard>
-            <span
-              className="cursor-pointer text-sm text-muted-foreground hover:underline"
+              <span className="text-muted-foreground">·</span>
+              <span className="shrink-0 text-[15px] text-muted-foreground">
+                {formatRelativeTime(post.createdAt)}
+              </span>
+            </div>
+            {!isOwner && currentUser && authorProfile && (
+              <Button
+                onClick={handleFollowClick}
+                onMouseEnter={() => setIsHoveringFollow(true)}
+                onMouseLeave={() => setIsHoveringFollow(false)}
+                variant={
+                  authorProfile.isFollowing
+                    ? isHoveringFollow
+                      ? "follow-danger"
+                      : "follow-active"
+                    : "follow"
+                }
+                size="sm"
+                className="ml-2 min-w-[80px] cursor-pointer"
+                disabled={follow.isPending || unfollow.isPending}
+              >
+                {authorProfile.isFollowing
+                  ? isHoveringFollow
+                    ? "언팔로우"
+                    : "팔로잉"
+                  : "팔로우"}
+              </Button>
+            )}
+          </div>
+
+          {/* Content */}
+          <p className="mt-0.5 text-[15px] leading-normal text-foreground">
+            {post.content}
+          </p>
+
+          {/* Action Buttons */}
+          <div className="-ml-2 mt-1.5 flex max-w-[425px] items-center justify-between">
+            {/* Reply */}
+            <button
               onClick={(e) => {
-                e.stopPropagation()
-                navigate(`/${post.author.username}`)
+                e.stopPropagation();
+                navigate(`/post/${post.id}`);
               }}
+              className="group flex cursor-pointer items-center gap-1.5 rounded-full border-none bg-transparent p-2 transition-colors hover:bg-primary/10"
             >
-              @{post.author.username}
-            </span>
+              <MessageCircle
+                size={18}
+                className="text-muted-foreground transition-colors group-hover:text-primary"
+              />
+              <span className="text-[13px] text-muted-foreground transition-colors group-hover:text-primary">
+                {post.replyCount || ""}
+              </span>
+            </button>
+
+            {/* Repost */}
+            <button
+              onClick={(e) => e.stopPropagation()}
+              className="group flex cursor-pointer items-center gap-1.5 rounded-full border-none bg-transparent p-2 transition-colors hover:bg-green-500/10"
+            >
+              <Repeat2
+                size={18}
+                className="text-muted-foreground transition-colors group-hover:text-green-500"
+              />
+            </button>
+
+            {/* Like */}
+            <button
+              onClick={handleLikeClick}
+              className="group flex cursor-pointer items-center gap-1.5 rounded-full border-none bg-transparent p-2 transition-colors hover:bg-red-500/10"
+            >
+              <Heart
+                size={18}
+                className={cn(
+                  "transition-colors group-hover:text-red-500",
+                  post.isLiked
+                    ? "fill-red-500 text-red-500"
+                    : "text-muted-foreground",
+                )}
+              />
+              <span
+                className={cn(
+                  "text-[13px] transition-colors group-hover:text-red-500",
+                  post.isLiked ? "text-red-500" : "text-muted-foreground",
+                )}
+              >
+                {post.likeCount || ""}
+              </span>
+            </button>
+
+            {/* Share */}
+            <button
+              onClick={(e) => e.stopPropagation()}
+              className="group flex cursor-pointer items-center gap-1.5 rounded-full border-none bg-transparent p-2 transition-colors hover:bg-primary/10"
+            >
+              <Share
+                size={18}
+                className="text-muted-foreground transition-colors group-hover:text-primary"
+              />
+            </button>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          {!isOwner && currentUser && authorProfile && (
-            <Button
-              onClick={handleFollowClick}
-              onMouseEnter={() => setIsHoveringFollow(true)}
-              onMouseLeave={() => setIsHoveringFollow(false)}
-              variant={
-                authorProfile.isFollowing
-                  ? isHoveringFollow
-                    ? 'follow-danger'
-                    : 'follow-active'
-                  : 'follow'
-              }
-              size="sm"
-              className="min-w-[90px] cursor-pointer"
-              disabled={follow.isPending || unfollow.isPending}
-            >
-              {authorProfile.isFollowing
-                ? isHoveringFollow
-                  ? '언팔로우'
-                  : '팔로잉'
-                : '팔로우'}
-            </Button>
-          )}
-          <span className={cn('rounded-full px-2 py-0.5 text-xs font-medium', visibilityClasses[post.visibility])}>
-            {visibilityLabel[post.visibility]}
-          </span>
-        </div>
       </div>
-      <p className="mb-2 text-[15px] leading-normal text-foreground">{post.content}</p>
-      <div className="flex items-center gap-4">
-        <span className="text-[13px] text-muted-foreground">
-          {new Date(post.createdAt).toLocaleString()}
-        </span>
-        <div className="flex items-center gap-1 text-muted-foreground">
-          <MessageCircle size={16} />
-          <span className="text-[13px]">{post.replyCount}</span>
-        </div>
-        <button
-          onClick={handleLikeClick}
-          className="group flex cursor-pointer items-center gap-1 border-none bg-transparent p-0"
-        >
-          <Heart
-            size={16}
-            className={cn(
-              'transition-colors group-hover:text-red-500',
-              post.isLiked ? 'fill-red-500 text-red-500' : 'text-muted-foreground',
-            )}
-          />
-          <span
-            className={cn(
-              'text-[13px] transition-colors group-hover:text-red-500',
-              post.isLiked ? 'text-red-500' : 'text-muted-foreground',
-            )}
-          >
-            {post.likeCount}
-          </span>
-        </button>
-      </div>
-    </div>
-  )
+    </article>
+  );
 }
 
-export default PostCard
+export default PostCard;

--- a/frontend/src/components/ReplyCard.tsx
+++ b/frontend/src/components/ReplyCard.tsx
@@ -58,11 +58,19 @@ export default function ReplyCard({
         )}
       >
         <div className="flex flex-col items-center">
-          <UserAvatar
-            profileImageUrl={reply.author.profileImageUrl}
-            displayName={reply.author.displayName || reply.author.username}
-            size="md"
-          />
+          <div
+            className="shrink-0 cursor-pointer"
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/${reply.author.username}`);
+            }}
+          >
+            <UserAvatar
+              profileImageUrl={reply.author.profileImageUrl}
+              displayName={reply.author.displayName || reply.author.username}
+              size="md"
+            />
+          </div>
           {showLine && (
             <div className="mt-1 w-0.5 flex-1 bg-border" />
           )}

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,0 +1,30 @@
+import { Outlet } from "react-router-dom";
+import Sidebar from "./Sidebar";
+import MobileNav from "./MobileNav";
+import RightPanel from "./RightPanel";
+
+export default function MainLayout() {
+  return (
+    <div className="mx-auto flex min-h-dvh max-w-[1280px] justify-center">
+      {/* Left Sidebar - hidden on mobile */}
+      <div className="hidden w-[68px] shrink-0 md:block xl:w-[275px]">
+        <div className="sticky top-0">
+          <Sidebar />
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <main className="w-full max-w-[600px] border-r border-border pb-16 md:pb-0">
+        <Outlet />
+      </main>
+
+      {/* Right Panel - hidden on tablet and mobile */}
+      <div className="hidden w-[350px] shrink-0 lg:block">
+        <RightPanel />
+      </div>
+
+      {/* Mobile Bottom Nav */}
+      <MobileNav />
+    </div>
+  );
+}

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -1,0 +1,32 @@
+import { NavLink } from "react-router-dom";
+import { Home, User } from "lucide-react";
+import { useAuth } from "@/hooks/useAuthContext";
+import { cn } from "@/lib/utils";
+
+export default function MobileNav() {
+  const { user } = useAuth();
+
+  const items = [
+    { to: "/", icon: Home },
+    ...(user ? [{ to: `/${user.username}`, icon: User }] : []),
+  ];
+
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-50 flex items-center justify-around border-t border-border bg-background/80 pb-safe backdrop-blur-xl md:hidden">
+      {items.map(({ to, icon: Icon }) => (
+        <NavLink
+          key={to}
+          to={to}
+          className={({ isActive }) =>
+            cn(
+              "flex flex-1 items-center justify-center py-3 transition-colors",
+              isActive ? "text-foreground" : "text-muted-foreground",
+            )
+          }
+        >
+          <Icon className="h-6 w-6" strokeWidth={1.75} />
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/components/layout/RightPanel.tsx
+++ b/frontend/src/components/layout/RightPanel.tsx
@@ -1,0 +1,43 @@
+import { Input } from "@/components/ui/input";
+import { Search } from "lucide-react";
+
+export default function RightPanel() {
+  return (
+    <aside className="sticky top-0 h-dvh px-4 py-3">
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="검색"
+          className="h-[42px] rounded-full border-none bg-secondary pl-10 text-[15px] focus-visible:ring-1 focus-visible:ring-primary"
+        />
+      </div>
+
+      {/* Trending / What's happening */}
+      <div className="mt-4 overflow-hidden rounded-2xl bg-secondary">
+        <h2 className="px-4 py-3 text-[20px] font-extrabold">트렌드</h2>
+        {[
+          { category: "기술", topic: "React 19", posts: "12.4K" },
+          { category: "개발", topic: "TypeScript", posts: "8.2K" },
+          { category: "한국", topic: "Claude Code", posts: "5.1K" },
+        ].map(({ category, topic, posts }) => (
+          <div
+            key={topic}
+            className="cursor-pointer px-4 py-3 transition-colors hover:bg-foreground/5"
+          >
+            <div className="text-[13px] text-muted-foreground">
+              {category}에서 트렌드
+            </div>
+            <div className="text-[15px] font-bold">{topic}</div>
+            <div className="text-[13px] text-muted-foreground">
+              {posts} posts
+            </div>
+          </div>
+        ))}
+        <div className="cursor-pointer px-4 py-3 text-[15px] text-primary transition-colors hover:bg-foreground/5">
+          더 보기
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,89 @@
+import { NavLink, useNavigate } from "react-router-dom";
+import { Home, User, LogOut, Feather } from "lucide-react";
+import { useAuth } from "@/hooks/useAuthContext";
+import UserAvatar from "@/components/UserAvatar";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const navItems = [{ to: "/", icon: Home, label: "홈" }] as const;
+
+export default function Sidebar() {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  return (
+    <aside className="flex h-dvh flex-col items-end border-r border-border px-2 py-3 xl:px-4">
+      <div className="flex flex-1 flex-col gap-1 xl:w-full">
+        {/* Logo */}
+        <div className="mb-2 flex h-12 w-12 items-center justify-center rounded-full transition-colors hover:bg-primary/10 xl:ml-1">
+          <Feather className="h-7 w-7 text-primary" />
+        </div>
+
+        {/* Nav Links */}
+        {navItems.map(({ to, icon: Icon, label }) => (
+          <NavLink
+            key={to}
+            to={to}
+            className={({ isActive }) =>
+              cn(
+                "group flex items-center gap-4 rounded-full px-3 py-3 text-[20px] transition-colors hover:bg-foreground/10 xl:pr-6",
+                isActive ? "font-bold text-foreground" : "text-foreground/80",
+              )
+            }
+          >
+            <Icon className="h-[26px] w-[26px]" strokeWidth={1.75} />
+            <span className="hidden xl:inline">{label}</span>
+          </NavLink>
+        ))}
+
+        {/* Profile Link */}
+        {user && (
+          <NavLink
+            to={`/${user.username}`}
+            className={({ isActive }) =>
+              cn(
+                "group flex items-center gap-4 rounded-full px-3 py-3 text-[20px] transition-colors hover:bg-foreground/10 xl:pr-6",
+                isActive ? "font-bold text-foreground" : "text-foreground/80",
+              )
+            }
+          >
+            <User className="h-[26px] w-[26px]" strokeWidth={1.75} />
+            <span className="hidden xl:inline">프로필</span>
+          </NavLink>
+        )}
+
+        {/* Post Button */}
+        <Button
+          onClick={() => navigate("/")}
+          className="mt-3 h-12 w-12 rounded-full text-[17px] font-bold xl:w-full"
+        >
+          <Feather className="h-5 w-5 xl:hidden" />
+          <span className="hidden xl:inline">게시하기</span>
+        </Button>
+      </div>
+
+      {/* User Info & Logout */}
+      {user && (
+        <button
+          onClick={logout}
+          className="flex w-full cursor-pointer items-center gap-3 rounded-full border-none bg-transparent p-3 text-left transition-colors hover:bg-foreground/10"
+        >
+          <UserAvatar
+            profileImageUrl={user.profileImageUrl}
+            displayName={user.displayName}
+            size="sm"
+          />
+          <div className="hidden min-w-0 flex-1 xl:block">
+            <div className="truncate text-[15px] font-bold text-foreground">
+              {user.displayName || user.username}
+            </div>
+            <div className="truncate text-[13px] text-muted-foreground">
+              @{user.username}
+            </div>
+          </div>
+          <LogOut className="hidden h-4 w-4 text-muted-foreground xl:block" />
+        </button>
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
@@ -19,16 +19,16 @@ const buttonVariants = cva(
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         follow:
-          "rounded-full border-none bg-foreground text-background font-bold hover:bg-foreground/90",
+          "border-none bg-foreground text-background font-bold hover:bg-foreground/90",
         "follow-active":
-          "rounded-full border border-muted-foreground/50 bg-transparent text-foreground font-bold",
+          "border border-muted-foreground/50 bg-transparent text-foreground font-bold",
         "follow-danger":
-          "rounded-full border border-destructive/50 bg-transparent text-destructive font-bold hover:bg-destructive/10",
+          "border border-destructive/50 bg-transparent text-destructive font-bold hover:bg-destructive/10",
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
+        sm: "h-9 px-3",
+        lg: "h-11 px-8",
         icon: "h-10 w-10",
       },
     },

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-2xl border bg-card text-card-foreground shadow-sm",
       className
     )}
     {...props}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-2xl",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-xl border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded-xl border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}

--- a/frontend/src/lib/formatTime.ts
+++ b/frontend/src/lib/formatTime.ts
@@ -1,0 +1,23 @@
+const MINUTE = 60;
+const HOUR = 3600;
+const DAY = 86400;
+
+export function formatRelativeTime(dateString: string): string {
+  const now = Date.now();
+  const then = new Date(dateString).getTime();
+  const diffSec = Math.floor((now - then) / 1000);
+
+  if (diffSec < MINUTE) return "방금";
+  if (diffSec < HOUR) return `${Math.floor(diffSec / MINUTE)}분`;
+  if (diffSec < DAY) return `${Math.floor(diffSec / HOUR)}시간`;
+  if (diffSec < DAY * 7) return `${Math.floor(diffSec / DAY)}일`;
+
+  const date = new Date(dateString);
+  const thisYear = new Date().getFullYear();
+
+  if (date.getFullYear() === thisYear) {
+    return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+  }
+
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,35 +1,36 @@
-import { usePosts } from '@/hooks/usePosts'
-import { useAuth } from '@/hooks/useAuthContext'
-import PostCard from '@/components/PostCard'
-import ComposeForm from '@/components/ComposeForm'
+import { usePosts } from "@/hooks/usePosts";
+import PostCard from "@/components/PostCard";
+import ComposeForm from "@/components/ComposeForm";
 
 export default function HomePage() {
-  const { user, logout } = useAuth()
-  const { data: posts, isLoading, error } = usePosts()
+  const { data: posts, isLoading, error } = usePosts();
 
   return (
-    <div className="mx-auto max-w-[600px]">
-      <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/65 px-4 py-3 backdrop-blur-xl">
-        <h1 className="text-xl font-bold">Home</h1>
-        <div className="flex items-center gap-3">
-          <span className="text-sm text-muted-foreground">@{user?.username}</span>
-          <button
-            onClick={logout}
-            className="cursor-pointer rounded-full border border-muted-foreground/50 bg-transparent px-4 py-1.5 text-sm font-bold text-foreground transition-colors hover:bg-foreground/10"
-          >
-            로그아웃
-          </button>
-        </div>
+    <>
+      <header className="sticky top-0 z-10 border-b border-border bg-background/65 backdrop-blur-xl">
+        <h1 className="px-4 py-3 text-xl font-bold">홈</h1>
       </header>
       <ComposeForm />
       <main>
-        {isLoading && <p>Loading posts...</p>}
-        {error && <p>Error: {error.message}</p>}
-        {!isLoading && !error && (!posts || posts.length === 0) && (
-          <p className="px-4 py-8 text-center text-muted-foreground">No posts yet.</p>
+        {isLoading && (
+          <div className="flex justify-center py-8">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          </div>
         )}
-        {posts?.map((post) => <PostCard key={post.id} post={post} />)}
+        {error && (
+          <p className="px-4 py-8 text-center text-destructive">
+            Error: {error.message}
+          </p>
+        )}
+        {!isLoading && !error && (!posts || posts.length === 0) && (
+          <p className="px-4 py-8 text-center text-muted-foreground">
+            아직 게시글이 없습니다.
+          </p>
+        )}
+        {posts?.map((post) => (
+          <PostCard key={post.id} post={post} />
+        ))}
       </main>
-    </div>
-  )
+    </>
+  );
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,61 +1,78 @@
-import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
-import { useLogin } from '@/hooks/useAuth'
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Feather } from "lucide-react";
+import { useLogin } from "@/hooks/useAuth";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 
 export default function LoginPage() {
-  const navigate = useNavigate()
-  const login = useLogin()
+  const navigate = useNavigate();
+  const login = useLogin();
 
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
 
   function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    login.mutate(
-      { email, password },
-      { onSuccess: () => navigate('/') },
-    )
+    e.preventDefault();
+    login.mutate({ email, password }, { onSuccess: () => navigate("/") });
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center p-5">
-      <div className="w-full max-w-[400px] rounded-2xl border border-border bg-background p-8">
-        <h1 className="mb-6 text-center text-2xl font-bold">로그인</h1>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-          <input
-            type="email"
-            placeholder="이메일"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="rounded-lg border border-border bg-transparent px-4 py-3 text-[15px] text-foreground outline-none transition-colors focus:border-primary"
-            required
-          />
-          <input
-            type="password"
-            placeholder="비밀번호"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="rounded-lg border border-border bg-transparent px-4 py-3 text-[15px] text-foreground outline-none transition-colors focus:border-primary"
-            required
-          />
+    <div className="flex min-h-dvh items-center justify-center p-5">
+      <div className="w-full max-w-[400px]">
+        <div className="mb-8 flex justify-center">
+          <Feather className="h-10 w-10 text-primary" />
+        </div>
+        <h1 className="mb-8 text-center text-[28px] font-extrabold tracking-tight">
+          로그인
+        </h1>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="email">이메일</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="name@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="password">비밀번호</Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="비밀번호를 입력하세요"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
           {login.error && (
-            <p className="m-0 text-[13px] text-destructive">{login.error.message}</p>
+            <p className="text-[13px] text-destructive">
+              {login.error.message}
+            </p>
           )}
-          <button
+          <Button
             type="submit"
-            className="cursor-pointer rounded-full bg-primary py-3 text-[15px] font-bold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            className="mt-2 rounded-full py-6 text-[15px] font-bold"
             disabled={login.isPending}
           >
-            {login.isPending ? '로그인 중...' : '로그인'}
-          </button>
+            {login.isPending ? "로그인 중..." : "로그인"}
+          </Button>
         </form>
-        <p className="mt-4 text-center text-sm text-muted-foreground">
-          계정이 없나요?{' '}
-          <Link to="/register" className="text-primary no-underline hover:underline">
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          계정이 없나요?{" "}
+          <Link
+            to="/register"
+            className="text-primary no-underline hover:underline"
+          >
             회원가입
           </Link>
         </p>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { Feather } from 'lucide-react'
 import { useUpdateProfile } from '@/hooks/useProfile'
 import { useAuth } from '@/hooks/useAuthContext'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
 
 export default function OnboardingPage() {
   const navigate = useNavigate()
@@ -25,42 +29,45 @@ export default function OnboardingPage() {
     )
   }
 
-  function handleSkip() {
-    navigate('/')
-  }
-
   return (
-    <div className="flex min-h-screen items-center justify-center p-5">
-      <div className="w-full max-w-[400px] rounded-2xl border border-border bg-background p-8">
-        <h1 className="mb-2 text-center text-2xl font-bold">환영합니다!</h1>
-        <p className="mb-6 text-center text-sm text-muted-foreground">표시할 이름을 설정해주세요.</p>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-          <input
-            type="text"
-            placeholder="표시 이름"
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            className="rounded-lg border border-border bg-transparent px-4 py-3 text-[15px] text-foreground outline-none transition-colors focus:border-primary"
-            maxLength={50}
-            autoFocus
-          />
+    <div className="flex min-h-dvh items-center justify-center p-5">
+      <div className="w-full max-w-[400px]">
+        <div className="mb-8 flex justify-center">
+          <Feather className="h-10 w-10 text-primary" />
+        </div>
+        <h1 className="mb-2 text-center text-[28px] font-extrabold tracking-tight">환영합니다!</h1>
+        <p className="mb-8 text-center text-sm text-muted-foreground">표시할 이름을 설정해주세요.</p>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="displayName">표시 이름</Label>
+            <Input
+              id="displayName"
+              type="text"
+              placeholder="이름을 입력하세요"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              maxLength={50}
+              autoFocus
+            />
+          </div>
           {updateProfile.error && (
-            <p className="m-0 text-[13px] text-destructive">{updateProfile.error.message}</p>
+            <p className="text-[13px] text-destructive">{updateProfile.error.message}</p>
           )}
-          <button
+          <Button
             type="submit"
-            className="cursor-pointer rounded-full bg-primary py-3 text-[15px] font-bold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            className="mt-2 py-6 text-[15px] font-bold"
             disabled={updateProfile.isPending || !displayName.trim()}
           >
             {updateProfile.isPending ? '저장 중...' : '시작하기'}
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
-            onClick={handleSkip}
-            className="cursor-pointer rounded-full border border-muted-foreground/50 bg-transparent py-3 text-[15px] font-bold text-foreground transition-colors hover:bg-foreground/10"
+            onClick={() => navigate('/')}
+            variant="outline"
+            className="py-6 text-[15px] font-bold"
           >
             나중에 하기
-          </button>
+          </Button>
         </form>
       </div>
     </div>

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Heart, MessageCircle } from "lucide-react";
+import { Heart, MessageCircle, Repeat2, Share, ArrowLeft } from "lucide-react";
 import { usePostDetail, useParentChain } from "@/hooks/usePosts";
 import { useAuth } from "@/hooks/useAuthContext";
 import { useProfile } from "@/hooks/useProfile";
 import { useFollow, useUnfollow } from "@/hooks/useFollow";
 import { useLike } from "@/hooks/useLike";
+import { formatRelativeTime } from "@/lib/formatTime";
 import ProfileHoverCard from "@/components/ProfileHoverCard";
 import UserAvatar from "@/components/UserAvatar";
 import { Button } from "@/components/ui/button";
@@ -35,7 +36,9 @@ export default function PostDetailPage() {
 
   if (isLoading)
     return (
-      <p className="px-4 py-8 text-center text-muted-foreground">Loading...</p>
+      <div className="flex justify-center py-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
     );
   if (error) {
     console.error("PostDetailPage error:", error);
@@ -48,7 +51,7 @@ export default function PostDetailPage() {
   if (!post)
     return (
       <p className="px-4 py-8 text-center text-muted-foreground">
-        Post not found.
+        게시글을 찾을 수 없습니다.
       </p>
     );
 
@@ -66,16 +69,17 @@ export default function PostDetailPage() {
   }
 
   return (
-    <div className="mx-auto max-w-[600px]">
+    <>
       <header className="sticky top-0 z-10 flex items-center gap-4 border-b border-border bg-background/65 px-4 py-3 backdrop-blur-xl">
         <button
-          className="cursor-pointer rounded-full border-none bg-none p-1 px-2 text-xl text-foreground transition-colors hover:bg-foreground/10"
+          className="cursor-pointer rounded-full border-none bg-transparent p-2 text-foreground transition-colors hover:bg-foreground/10"
           onClick={() => navigate(-1)}
         >
-          &larr;
+          <ArrowLeft className="h-5 w-5" />
         </button>
-        <h1 className="text-xl font-bold">Post</h1>
+        <h1 className="text-xl font-bold">게시물</h1>
       </header>
+
       {parentChain && parentChain.length > 0 && (
         <div className="border-b border-border">
           {parentChain.map((parent) => (
@@ -86,11 +90,16 @@ export default function PostDetailPage() {
 
       <article className="p-4">
         <div className="mb-4 flex items-center gap-3">
-          <UserAvatar
-            profileImageUrl={post.author.profileImageUrl}
-            displayName={post.author.displayName || post.author.username}
-            size="lg"
-          />
+          <div
+            className="shrink-0 cursor-pointer"
+            onClick={() => navigate(`/${post.author.username}`)}
+          >
+            <UserAvatar
+              profileImageUrl={post.author.profileImageUrl}
+              displayName={post.author.displayName || post.author.username}
+              size="lg"
+            />
+          </div>
           <div className="flex flex-1 flex-col">
             <ProfileHoverCard
               handle={post.author.username}
@@ -140,17 +149,55 @@ export default function PostDetailPage() {
             </Button>
           )}
         </div>
+
         <p className="mb-4 text-[17px] leading-relaxed text-foreground">
           {post.content}
         </p>
-        <div className="flex items-center gap-4 border-t border-border pt-4">
-          <span className="text-sm text-muted-foreground">
-            {new Date(post.createdAt).toLocaleString()}
-          </span>
+
+        <div className="text-[15px] text-muted-foreground">
+          {formatRelativeTime(post.createdAt)} ·{" "}
+          {new Date(post.createdAt).toLocaleString("ko-KR")}
+        </div>
+
+        {/* Stats */}
+        {(post.likeCount > 0 || post.replyCount > 0) && (
+          <div className="mt-3 flex gap-4 border-t border-border pt-3 text-sm">
+            {post.replyCount > 0 && (
+              <span className="text-muted-foreground">
+                <strong className="text-foreground">{post.replyCount}</strong>{" "}
+                답글
+              </span>
+            )}
+            {post.likeCount > 0 && (
+              <span className="text-muted-foreground">
+                <strong className="text-foreground">{post.likeCount}</strong>{" "}
+                좋아요
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Action Buttons */}
+        <div className="flex items-center justify-around border-t border-border pt-1 mt-3">
+          <button
+            onClick={() => {}}
+            className="group flex cursor-pointer items-center justify-center rounded-full border-none bg-transparent p-2 transition-colors hover:bg-primary/10"
+          >
+            <MessageCircle
+              size={20}
+              className="text-muted-foreground transition-colors group-hover:text-primary"
+            />
+          </button>
+          <button className="group flex cursor-pointer items-center justify-center rounded-full border-none bg-transparent p-2 transition-colors hover:bg-green-500/10">
+            <Repeat2
+              size={20}
+              className="text-muted-foreground transition-colors group-hover:text-green-500"
+            />
+          </button>
           <button
             onClick={handleLikeClick}
             disabled={like.isPending}
-            className="group flex cursor-pointer items-center gap-1.5 border-none bg-transparent p-0 disabled:opacity-50"
+            className="group flex cursor-pointer items-center justify-center rounded-full border-none bg-transparent p-2 transition-colors hover:bg-red-500/10 disabled:opacity-50"
           >
             <Heart
               size={20}
@@ -161,19 +208,13 @@ export default function PostDetailPage() {
                   : "text-muted-foreground",
               )}
             />
-            <span
-              className={cn(
-                "text-sm transition-colors group-hover:text-red-500",
-                post.isLiked ? "text-red-500" : "text-muted-foreground",
-              )}
-            >
-              {post.likeCount}
-            </span>
           </button>
-          <div className="flex items-center gap-1.5 text-muted-foreground">
-            <MessageCircle size={20} />
-            <span className="text-sm">{post.replyCount}</span>
-          </div>
+          <button className="group flex cursor-pointer items-center justify-center rounded-full border-none bg-transparent p-2 transition-colors hover:bg-primary/10">
+            <Share
+              size={20}
+              className="text-muted-foreground transition-colors group-hover:text-primary"
+            />
+          </button>
         </div>
       </article>
 
@@ -190,10 +231,10 @@ export default function PostDetailPage() {
         ))}
         {(!post.topReplies || post.topReplies.length === 0) && (
           <p className="px-4 py-6 text-center text-sm text-muted-foreground">
-            No replies yet.
+            아직 답글이 없습니다.
           </p>
         )}
       </section>
-    </div>
+    </>
   );
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,81 +1,99 @@
-import { useState } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
-import { useProfile } from '@/hooks/useProfile'
-import { useAuth } from '@/hooks/useAuthContext'
-import { useFollow, useUnfollow } from '@/hooks/useFollow'
-import EditProfileModal from '@/components/EditProfileModal'
-import FollowListModal from '@/components/FollowListModal'
-import UserAvatar from '@/components/UserAvatar'
-import { Button } from '@/components/ui/button'
+import { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { ArrowLeft, CalendarDays } from "lucide-react";
+import { useProfile } from "@/hooks/useProfile";
+import { useAuth } from "@/hooks/useAuthContext";
+import { useFollow, useUnfollow } from "@/hooks/useFollow";
+import EditProfileModal from "@/components/EditProfileModal";
+import FollowListModal from "@/components/FollowListModal";
+import UserAvatar from "@/components/UserAvatar";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type Tab = "posts" | "replies" | "likes";
 
 export default function ProfilePage() {
-  const { handle } = useParams<{ handle: string }>()
-  const navigate = useNavigate()
-  const { user: currentUser } = useAuth()
-  const { data: profile, isLoading, error } = useProfile(handle ?? '')
-  const [showEditModal, setShowEditModal] = useState(false)
+  const { handle } = useParams<{ handle: string }>();
+  const navigate = useNavigate();
+  const { user: currentUser } = useAuth();
+  const { data: profile, isLoading, error } = useProfile(handle ?? "");
+  const [showEditModal, setShowEditModal] = useState(false);
   const [followListType, setFollowListType] = useState<
-    'followers' | 'following' | null
-  >(null)
-  const [isHoveringFollow, setIsHoveringFollow] = useState(false)
+    "followers" | "following" | null
+  >(null);
+  const [isHoveringFollow, setIsHoveringFollow] = useState(false);
+  const [activeTab, setActiveTab] = useState<Tab>("posts");
 
-  const follow = useFollow(handle ?? '')
-  const unfollow = useUnfollow(handle ?? '')
+  const follow = useFollow(handle ?? "");
+  const unfollow = useUnfollow(handle ?? "");
 
-  const isOwner = currentUser?.username === profile?.username
+  const isOwner = currentUser?.username === profile?.username;
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-[600px]">
-        <p className="px-4 py-8 text-center text-muted-foreground">프로필을 불러오는 중...</p>
+      <div className="flex justify-center py-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
-    )
+    );
   }
 
   if (error || !profile) {
     return (
-      <div className="mx-auto max-w-[600px]">
+      <>
         <header className="sticky top-0 z-10 flex items-center gap-4 border-b border-border bg-background/65 px-4 py-2 backdrop-blur-xl">
           <button
             onClick={() => navigate(-1)}
-            className="cursor-pointer rounded-full border-none bg-transparent p-2 text-lg text-foreground transition-colors hover:bg-foreground/10"
+            className="cursor-pointer rounded-full border-none bg-transparent p-2 text-foreground transition-colors hover:bg-foreground/10"
           >
-            &larr;
+            <ArrowLeft className="h-5 w-5" />
           </button>
           <span className="text-xl font-bold">프로필</span>
         </header>
         <p className="px-4 py-8 text-center text-destructive">
-          {error?.message ?? '사용자를 찾을 수 없습니다.'}
+          {error?.message ?? "사용자를 찾을 수 없습니다."}
         </p>
-      </div>
-    )
+      </>
+    );
   }
 
-  const joinedDate = new Date(profile.createdAt).toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-  })
+  const joinedDate = new Date(profile.createdAt).toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+  });
 
   function handleFollowClick() {
     if (profile?.isFollowing) {
-      unfollow.mutate()
+      unfollow.mutate();
     } else {
-      follow.mutate()
+      follow.mutate();
     }
   }
 
+  const tabs: { key: Tab; label: string }[] = [
+    { key: "posts", label: "게시물" },
+    { key: "replies", label: "답글" },
+    { key: "likes", label: "마음에 들어요" },
+  ];
+
   return (
-    <div className="mx-auto max-w-[600px]">
+    <>
+      {/* Header */}
       <header className="sticky top-0 z-10 flex items-center gap-4 border-b border-border bg-background/65 px-4 py-2 backdrop-blur-xl">
         <button
           onClick={() => navigate(-1)}
-          className="cursor-pointer rounded-full border-none bg-transparent p-2 text-lg text-foreground transition-colors hover:bg-foreground/10"
+          className="cursor-pointer rounded-full border-none bg-transparent p-2 text-foreground transition-colors hover:bg-foreground/10"
         >
-          &larr;
+          <ArrowLeft className="h-5 w-5" />
         </button>
-        <span className="text-xl font-bold">{profile.displayName}</span>
+        <div>
+          <div className="text-xl font-bold leading-tight">
+            {profile.displayName}
+          </div>
+          <div className="text-[13px] text-muted-foreground">0 posts</div>
+        </div>
       </header>
 
+      {/* Banner */}
       {profile.headerImageUrl ? (
         <img
           src={profile.headerImageUrl}
@@ -83,11 +101,12 @@ export default function ProfilePage() {
           className="h-[200px] w-full object-cover"
         />
       ) : (
-        <div className="h-[200px] w-full bg-muted-foreground/30" />
+        <div className="h-[200px] w-full bg-muted-foreground/20" />
       )}
 
-      <div className="relative px-4">
-        <div className="-mt-10 flex items-start justify-between">
+      {/* Profile Info */}
+      <div className="px-4">
+        <div className="-mt-[66px] flex items-end justify-between">
           <UserAvatar
             profileImageUrl={profile.profileImageUrl}
             displayName={profile.displayName}
@@ -99,7 +118,7 @@ export default function ProfilePage() {
               onClick={() => setShowEditModal(true)}
               variant="outline"
               size="sm"
-              className="mt-12 cursor-pointer rounded-full"
+              className="cursor-pointer rounded-full"
             >
               프로필 수정
             </Button>
@@ -111,43 +130,89 @@ export default function ProfilePage() {
               variant={
                 profile.isFollowing
                   ? isHoveringFollow
-                    ? 'follow-danger'
-                    : 'follow-active'
-                  : 'follow'
+                    ? "follow-danger"
+                    : "follow-active"
+                  : "follow"
               }
               size="sm"
-              className="mt-12 min-w-[100px] cursor-pointer"
+              className="min-w-[100px] cursor-pointer"
               disabled={follow.isPending || unfollow.isPending}
             >
               {profile.isFollowing
                 ? isHoveringFollow
-                  ? '언팔로우'
-                  : '팔로잉'
-                : '팔로우'}
+                  ? "언팔로우"
+                  : "팔로잉"
+                : "팔로우"}
             </Button>
           ) : null}
         </div>
 
-        <div className="mt-3 border-b border-border pb-4">
+        <div className="mt-3">
           <div className="text-xl font-bold">{profile.displayName}</div>
-          <div className="text-[15px] text-muted-foreground">@{profile.username}</div>
-          {profile.bio && <p className="mt-3 whitespace-pre-wrap text-[15px] leading-relaxed">{profile.bio}</p>}
-          <div className="mt-3 text-sm text-muted-foreground">{joinedDate} 가입</div>
-          <div className="mt-3 flex gap-5">
-            <span
-              className="cursor-pointer text-sm text-muted-foreground hover:underline"
-              onClick={() => setFollowListType('following')}
-            >
-              <strong className="text-foreground">{profile.followingCount}</strong> 팔로잉
-            </span>
-            <span
-              className="cursor-pointer text-sm text-muted-foreground hover:underline"
-              onClick={() => setFollowListType('followers')}
-            >
-              <strong className="text-foreground">{profile.followersCount}</strong> 팔로워
-            </span>
+          <div className="text-[15px] text-muted-foreground">
+            @{profile.username}
           </div>
         </div>
+
+        {profile.bio && (
+          <p className="mt-3 whitespace-pre-wrap text-[15px] leading-relaxed">
+            {profile.bio}
+          </p>
+        )}
+
+        <div className="mt-3 flex items-center gap-1 text-sm text-muted-foreground">
+          <CalendarDays className="h-4 w-4" />
+          <span>{joinedDate} 가입</span>
+        </div>
+
+        <div className="mt-3 flex gap-5">
+          <span
+            className="cursor-pointer text-sm text-muted-foreground hover:underline"
+            onClick={() => setFollowListType("following")}
+          >
+            <strong className="text-foreground">
+              {profile.followingCount}
+            </strong>{" "}
+            팔로잉
+          </span>
+          <span
+            className="cursor-pointer text-sm text-muted-foreground hover:underline"
+            onClick={() => setFollowListType("followers")}
+          >
+            <strong className="text-foreground">
+              {profile.followersCount}
+            </strong>{" "}
+            팔로워
+          </span>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="mt-3 flex border-b border-border">
+        {tabs.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setActiveTab(key)}
+            className={cn(
+              "relative flex-1 cursor-pointer border-none bg-transparent py-4 text-center text-[15px] font-medium transition-colors hover:bg-foreground/5",
+              activeTab === key
+                ? "font-bold text-foreground"
+                : "text-muted-foreground",
+            )}
+          >
+            {label}
+            {activeTab === key && (
+              <div className="absolute bottom-0 left-1/2 h-1 w-14 -translate-x-1/2 rounded-full bg-primary" />
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab Content */}
+      <div className="py-8 text-center text-sm text-muted-foreground">
+        {activeTab === "posts" && "아직 게시물이 없습니다."}
+        {activeTab === "replies" && "아직 답글이 없습니다."}
+        {activeTab === "likes" && "아직 좋아요한 게시물이 없습니다."}
       </div>
 
       {showEditModal && currentUser && (
@@ -164,6 +229,6 @@ export default function ProfilePage() {
           onClose={() => setFollowListType(null)}
         />
       )}
-    </div>
-  )
+    </>
+  );
 }

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,103 +1,128 @@
-import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
-import { useRegister } from '@/hooks/useAuth'
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Feather } from "lucide-react";
+import { useRegister } from "@/hooks/useAuth";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 
 export default function RegisterPage() {
-  const navigate = useNavigate()
-  const register = useRegister()
+  const navigate = useNavigate();
+  const register = useRegister();
 
-  const [email, setEmail] = useState('')
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [validationError, setValidationError] = useState('')
+  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [validationError, setValidationError] = useState("");
 
   function validate(): boolean {
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      setValidationError('올바른 이메일 형식을 입력해주세요.')
-      return false
+      setValidationError("올바른 이메일 형식을 입력해주세요.");
+      return false;
     }
     if (username.length < 3) {
-      setValidationError('사용자 이름은 3자 이상이어야 합니다.')
-      return false
+      setValidationError("사용자 이름은 3자 이상이어야 합니다.");
+      return false;
     }
     if (password.length < 8) {
-      setValidationError('비밀번호는 8자 이상이어야 합니다.')
-      return false
+      setValidationError("비밀번호는 8자 이상이어야 합니다.");
+      return false;
     }
     if (password !== confirmPassword) {
-      setValidationError('비밀번호가 일치하지 않습니다.')
-      return false
+      setValidationError("비밀번호가 일치하지 않습니다.");
+      return false;
     }
-    setValidationError('')
-    return true
+    setValidationError("");
+    return true;
   }
 
   function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!validate()) return
+    e.preventDefault();
+    if (!validate()) return;
 
     register.mutate(
       { email, username, password },
-      { onSuccess: () => navigate('/onboarding') },
-    )
+      { onSuccess: () => navigate("/onboarding") },
+    );
   }
 
-  const error = validationError || (register.error ? register.error.message : '')
+  const error =
+    validationError || (register.error ? register.error.message : "");
 
   return (
-    <div className="flex min-h-screen items-center justify-center p-5">
-      <div className="w-full max-w-[400px] rounded-2xl border border-border bg-background p-8">
-        <h1 className="mb-6 text-center text-2xl font-bold">회원가입</h1>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-          <input
-            type="email"
-            placeholder="이메일"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className="rounded-lg border border-border bg-transparent px-4 py-3 text-[15px] text-foreground outline-none transition-colors focus:border-primary"
-            required
-          />
-          <input
-            type="text"
-            placeholder="사용자 이름"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            className="rounded-lg border border-border bg-transparent px-4 py-3 text-[15px] text-foreground outline-none transition-colors focus:border-primary"
-            required
-          />
-          <input
-            type="password"
-            placeholder="비밀번호"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="rounded-lg border border-border bg-transparent px-4 py-3 text-[15px] text-foreground outline-none transition-colors focus:border-primary"
-            required
-          />
-          <input
-            type="password"
-            placeholder="비밀번호 확인"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            className="rounded-lg border border-border bg-transparent px-4 py-3 text-[15px] text-foreground outline-none transition-colors focus:border-primary"
-            required
-          />
-          {error && <p className="m-0 text-[13px] text-destructive">{error}</p>}
-          <button
+    <div className="flex min-h-dvh items-center justify-center p-5">
+      <div className="w-full max-w-[400px]">
+        <div className="mb-8 flex justify-center">
+          <Feather className="h-10 w-10 text-primary" />
+        </div>
+        <h1 className="mb-8 text-center text-[28px] font-extrabold tracking-tight">
+          계정 만들기
+        </h1>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="email">이메일</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="name@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="username">사용자 이름</Label>
+            <Input
+              id="username"
+              type="text"
+              placeholder="username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="password">비밀번호</Label>
+            <Input
+              id="password"
+              type="password"
+              placeholder="8자 이상"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="confirmPassword">비밀번호 확인</Label>
+            <Input
+              id="confirmPassword"
+              type="password"
+              placeholder="비밀번호를 다시 입력하세요"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-[13px] text-destructive">{error}</p>}
+          <Button
             type="submit"
-            className="cursor-pointer rounded-full bg-primary py-3 text-[15px] font-bold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            className="mt-2 rounded-full py-6 text-[15px] font-bold"
             disabled={register.isPending}
           >
-            {register.isPending ? '가입 중...' : '가입하기'}
-          </button>
+            {register.isPending ? "가입 중..." : "가입하기"}
+          </Button>
         </form>
-        <p className="mt-4 text-center text-sm text-muted-foreground">
-          이미 계정이 있나요?{' '}
-          <Link to="/login" className="text-primary no-underline hover:underline">
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          이미 계정이 있나요?{" "}
+          <Link
+            to="/login"
+            className="text-primary no-underline hover:underline"
+          >
             로그인
           </Link>
         </p>
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## 📄 개요

> 이슈 #19 — 메인 페이지, 프로필 페이지 등 주요 UI 레이아웃 및 스타일링 고도화
> X(Twitter) 스타일 3단 반응형 레이아웃 구현 및 전체 UI 컴포넌트 리디자인

<br>

## 🔨 해야 할 일

- [x] [Frontend] 글로벌 네비게이션 바(GNB) 사이드바 컴포넌트에 Tailwind 디자인 적용 (반응형 대응)
- [x] [Frontend] 포스트 리스트 및 단일 포스트(PostCard) UI 디자인: Avatar, 상대시간, 본문, 상호작용 버튼(좋아요/리포스트/답글/공유) 배치
- [x] [Frontend] 프로필 페이지 UI 디자인: 사용자 헤더(배경), 프로필 사진(Avatar), 정보 텍스트 레이아웃, 탭 네비게이션 구성
- [x] [Frontend] 새 포스트 작성(ComposeForm) UI 디자인: 원형 글자 수 프로그레스, 사용자 아바타 표시
- [x] [Frontend] LoginPage/RegisterPage/OnboardingPage shadcn/ui 컴포넌트 마이그레이션
- [x] [Frontend] border-radius 통일: Button(rounded-full), Input/Textarea(rounded-xl), Card/Dialog(rounded-2xl)
- [x] [Frontend] 아바타 클릭 시 프로필 페이지 이동 (PostCard, PostDetailPage, ReplyCard)
- [x] [Test] 데스크톱, 태블릿, 모바일 등 다양한 화면 크기(Breakpoint)에서 반응형 UI 테스트 진행

<br>

## 🙋🏻 덧붙일 말

**반응형 브레이크포인트:**
- 데스크톱 (`xl+`, 1280px): 텍스트+아이콘 사이드바 275px + 피드 600px + 위젯 패널 350px
- 태블릿 (`md~lg`, 768px~1024px): 아이콘 사이드바 68px + 피드
- 모바일 (`<md`, ~768px): 하단 네비게이션 바 + 전체 너비 피드

Closes #19