### PR TITLE
feat: implement profile tab content (posts/replies/likes) (#31)

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -24,10 +24,17 @@ type PostResponse struct {
 	UpdatedAt  string `json:"updatedAt"`
 }
 
+type ParentPostSummary struct {
+	ID      string     `json:"id"`
+	Content string     `json:"content"`
+	Author  PostAuthor `json:"author"`
+}
+
 type PostDetailResponse struct {
 	ID         string               `json:"id"`
 	AuthorID   string               `json:"authorId"`
 	ParentID   *string              `json:"parentId"`
+	Parent     *ParentPostSummary   `json:"parent,omitempty"`
 	Content    string               `json:"content"`
 	Visibility string               `json:"visibility"`
 	Author     PostAuthor           `json:"author"`
@@ -61,7 +68,7 @@ func ToPostDetailResponse(p model.PostWithAuthor) PostDetailResponse {
 		parentID = &s
 	}
 
-	return PostDetailResponse{
+	resp := PostDetailResponse{
 		ID:         p.ID.String(),
 		AuthorID:   p.AuthorID.String(),
 		ParentID:   parentID,
@@ -78,4 +85,25 @@ func ToPostDetailResponse(p model.PostWithAuthor) PostDetailResponse {
 		CreatedAt:  p.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt:  p.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 	}
+
+	if p.ParentPostID != nil && p.ParentContent != nil && p.ParentAuthorUsername != nil {
+		resp.Parent = &ParentPostSummary{
+			ID:      p.ParentPostID.String(),
+			Content: *p.ParentContent,
+			Author: PostAuthor{
+				Username:        *p.ParentAuthorUsername,
+				DisplayName:     derefStr(p.ParentAuthorDisplayName),
+				ProfileImageURL: derefStr(p.ParentAuthorProfileImageURL),
+			},
+		}
+	}
+
+	return resp
+}
+
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }

--- a/backend/internal/handler/user_handler.go
+++ b/backend/internal/handler/user_handler.go
@@ -10,10 +10,11 @@ import (
 
 type UserHandler struct {
 	userService service.UserService
+	postService service.PostService
 }
 
-func NewUserHandler(userService service.UserService) *UserHandler {
-	return &UserHandler{userService: userService}
+func NewUserHandler(userService service.UserService, postService service.PostService) *UserHandler {
+	return &UserHandler{userService: userService, postService: postService}
 }
 
 func (h *UserHandler) GetProfile(c *fiber.Ctx) error {
@@ -22,14 +23,7 @@ func (h *UserHandler) GetProfile(c *fiber.Ctx) error {
 		return respondError(c, apperror.BadRequest("handle is required"))
 	}
 
-	var viewerID *uuid.UUID
-	if userIDStr, ok := c.Locals("userID").(string); ok {
-		if id, err := uuid.Parse(userIDStr); err == nil {
-			viewerID = &id
-		}
-	}
-
-	profile, err := h.userService.GetProfile(c.Context(), handle, viewerID)
+	profile, err := h.userService.GetProfile(c.Context(), handle, h.getViewerID(c))
 	if err != nil {
 		return respondError(c, err)
 	}
@@ -37,6 +31,66 @@ func (h *UserHandler) GetProfile(c *fiber.Ctx) error {
 	return c.JSON(dto.APIResponse{
 		Success: true,
 		Data:    profile,
+	})
+}
+
+func (h *UserHandler) getViewerID(c *fiber.Ctx) *uuid.UUID {
+	if userIDStr, ok := c.Locals("userID").(string); ok {
+		if id, err := uuid.Parse(userIDStr); err == nil {
+			return &id
+		}
+	}
+	return nil
+}
+
+func (h *UserHandler) GetUserPosts(c *fiber.Ctx) error {
+	handle := c.Params("handle")
+	if handle == "" {
+		return respondError(c, apperror.BadRequest("handle is required"))
+	}
+
+	posts, err := h.postService.ListPostsByHandle(c.Context(), handle, h.getViewerID(c))
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    posts,
+	})
+}
+
+func (h *UserHandler) GetUserReplies(c *fiber.Ctx) error {
+	handle := c.Params("handle")
+	if handle == "" {
+		return respondError(c, apperror.BadRequest("handle is required"))
+	}
+
+	replies, err := h.postService.ListRepliesByHandle(c.Context(), handle, h.getViewerID(c))
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    replies,
+	})
+}
+
+func (h *UserHandler) GetUserLikes(c *fiber.Ctx) error {
+	handle := c.Params("handle")
+	if handle == "" {
+		return respondError(c, apperror.BadRequest("handle is required"))
+	}
+
+	likes, err := h.postService.ListLikedPostsByHandle(c.Context(), handle, h.getViewerID(c))
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    likes,
 	})
 }
 

--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -32,4 +32,10 @@ type PostWithAuthor struct {
 	AuthorDisplayName     string
 	AuthorProfileImageURL string
 	IsLiked               bool
+	// Parent post info (optional, populated for replies in profile context)
+	ParentPostID               *uuid.UUID
+	ParentContent              *string
+	ParentAuthorUsername        *string
+	ParentAuthorDisplayName     *string
+	ParentAuthorProfileImageURL *string
 }

--- a/backend/internal/repository/post_repository.go
+++ b/backend/internal/repository/post_repository.go
@@ -20,6 +20,12 @@ type PostRepository interface {
 	FindRepliesByPostIDWithUser(ctx context.Context, postID, userID uuid.UUID, limit, offset int) ([]model.PostWithAuthor, error)
 	FindAuthorReplyByPostID(ctx context.Context, postID, authorID uuid.UUID) (*model.PostWithAuthor, error)
 	FindAuthorReplyByPostIDWithUser(ctx context.Context, postID, authorID, userID uuid.UUID) (*model.PostWithAuthor, error)
+	FindByAuthorHandle(ctx context.Context, handle string, limit, offset int) ([]model.PostWithAuthor, error)
+	FindByAuthorHandleWithUser(ctx context.Context, handle string, limit, offset int, userID uuid.UUID) ([]model.PostWithAuthor, error)
+	FindRepliesByAuthorHandle(ctx context.Context, handle string, limit, offset int) ([]model.PostWithAuthor, error)
+	FindRepliesByAuthorHandleWithUser(ctx context.Context, handle string, limit, offset int, userID uuid.UUID) ([]model.PostWithAuthor, error)
+	FindLikedByUserHandle(ctx context.Context, handle string, limit, offset int) ([]model.PostWithAuthor, error)
+	FindLikedByUserHandleWithViewer(ctx context.Context, handle string, limit, offset int, viewerID uuid.UUID) ([]model.PostWithAuthor, error)
 }
 
 type postRepository struct {
@@ -293,4 +299,178 @@ func (r *postRepository) FindRepliesByPostIDWithUser(ctx context.Context, postID
 		replies = append(replies, p)
 	}
 	return replies, rows.Err()
+}
+
+type scannable interface {
+	Next() bool
+	Scan(dest ...any) error
+	Close()
+	Err() error
+}
+
+func (r *postRepository) scanPostRows(rows scannable, withIsLiked bool) ([]model.PostWithAuthor, error) {
+	defer rows.Close()
+	var posts []model.PostWithAuthor
+	for rows.Next() {
+		var p model.PostWithAuthor
+		var visibility string
+		var scanArgs []any
+		scanArgs = append(scanArgs,
+			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
+		)
+		if withIsLiked {
+			scanArgs = append(scanArgs, &p.IsLiked)
+		}
+		if err := rows.Scan(scanArgs...); err != nil {
+			return nil, err
+		}
+		p.Visibility = model.Visibility(visibility)
+		posts = append(posts, p)
+	}
+	return posts, rows.Err()
+}
+
+func (r *postRepository) FindByAuthorHandle(ctx context.Context, handle string, limit, offset int) ([]model.PostWithAuthor, error) {
+	query := `
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.created_at, p.updated_at,
+		       u.username, u.display_name, u.profile_image_url
+		FROM posts p
+		JOIN users u ON p.author_id = u.id
+		WHERE u.username = $1 AND p.parent_id IS NULL
+		ORDER BY p.created_at DESC
+		LIMIT $2 OFFSET $3`
+
+	rows, err := r.pool.Query(ctx, query, handle, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	return r.scanPostRows(rows, false)
+}
+
+func (r *postRepository) FindByAuthorHandleWithUser(ctx context.Context, handle string, limit, offset int, userID uuid.UUID) ([]model.PostWithAuthor, error) {
+	query := `
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.created_at, p.updated_at,
+		       u.username, u.display_name, u.profile_image_url,
+		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $4 AND l.post_id = p.id) AS is_liked
+		FROM posts p
+		JOIN users u ON p.author_id = u.id
+		WHERE u.username = $1 AND p.parent_id IS NULL
+		ORDER BY p.created_at DESC
+		LIMIT $2 OFFSET $3`
+
+	rows, err := r.pool.Query(ctx, query, handle, limit, offset, userID)
+	if err != nil {
+		return nil, err
+	}
+	return r.scanPostRows(rows, true)
+}
+
+func (r *postRepository) scanReplyWithParentRows(rows scannable, withIsLiked bool) ([]model.PostWithAuthor, error) {
+	defer rows.Close()
+	var posts []model.PostWithAuthor
+	for rows.Next() {
+		var p model.PostWithAuthor
+		var visibility string
+		var scanArgs []any
+		scanArgs = append(scanArgs,
+			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
+		)
+		if withIsLiked {
+			scanArgs = append(scanArgs, &p.IsLiked)
+		}
+		scanArgs = append(scanArgs,
+			&p.ParentPostID, &p.ParentContent,
+			&p.ParentAuthorUsername, &p.ParentAuthorDisplayName, &p.ParentAuthorProfileImageURL,
+		)
+		if err := rows.Scan(scanArgs...); err != nil {
+			return nil, err
+		}
+		p.Visibility = model.Visibility(visibility)
+		posts = append(posts, p)
+	}
+	return posts, rows.Err()
+}
+
+func (r *postRepository) FindRepliesByAuthorHandle(ctx context.Context, handle string, limit, offset int) ([]model.PostWithAuthor, error) {
+	query := `
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.created_at, p.updated_at,
+		       u.username, u.display_name, u.profile_image_url,
+		       pp.id, pp.content,
+		       pu.username, pu.display_name, pu.profile_image_url
+		FROM posts p
+		JOIN users u ON p.author_id = u.id
+		LEFT JOIN posts pp ON pp.id = p.parent_id
+		LEFT JOIN users pu ON pu.id = pp.author_id
+		WHERE u.username = $1 AND p.parent_id IS NOT NULL
+		ORDER BY p.created_at DESC
+		LIMIT $2 OFFSET $3`
+
+	rows, err := r.pool.Query(ctx, query, handle, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	return r.scanReplyWithParentRows(rows, false)
+}
+
+func (r *postRepository) FindRepliesByAuthorHandleWithUser(ctx context.Context, handle string, limit, offset int, userID uuid.UUID) ([]model.PostWithAuthor, error) {
+	query := `
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.created_at, p.updated_at,
+		       u.username, u.display_name, u.profile_image_url,
+		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $4 AND l.post_id = p.id) AS is_liked,
+		       pp.id, pp.content,
+		       pu.username, pu.display_name, pu.profile_image_url
+		FROM posts p
+		JOIN users u ON p.author_id = u.id
+		LEFT JOIN posts pp ON pp.id = p.parent_id
+		LEFT JOIN users pu ON pu.id = pp.author_id
+		WHERE u.username = $1 AND p.parent_id IS NOT NULL
+		ORDER BY p.created_at DESC
+		LIMIT $2 OFFSET $3`
+
+	rows, err := r.pool.Query(ctx, query, handle, limit, offset, userID)
+	if err != nil {
+		return nil, err
+	}
+	return r.scanReplyWithParentRows(rows, true)
+}
+
+func (r *postRepository) FindLikedByUserHandle(ctx context.Context, handle string, limit, offset int) ([]model.PostWithAuthor, error) {
+	query := `
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.created_at, p.updated_at,
+		       u.username, u.display_name, u.profile_image_url
+		FROM likes lk
+		JOIN users target ON target.username = $1
+		JOIN posts p ON p.id = lk.post_id
+		JOIN users u ON p.author_id = u.id
+		WHERE lk.user_id = target.id
+		ORDER BY lk.created_at DESC
+		LIMIT $2 OFFSET $3`
+
+	rows, err := r.pool.Query(ctx, query, handle, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	return r.scanPostRows(rows, false)
+}
+
+func (r *postRepository) FindLikedByUserHandleWithViewer(ctx context.Context, handle string, limit, offset int, viewerID uuid.UUID) ([]model.PostWithAuthor, error) {
+	query := `
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.created_at, p.updated_at,
+		       u.username, u.display_name, u.profile_image_url,
+		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $4 AND l.post_id = p.id) AS is_liked
+		FROM likes lk
+		JOIN users target ON target.username = $1
+		JOIN posts p ON p.id = lk.post_id
+		JOIN users u ON p.author_id = u.id
+		WHERE lk.user_id = target.id
+		ORDER BY lk.created_at DESC
+		LIMIT $2 OFFSET $3`
+
+	rows, err := r.pool.Query(ctx, query, handle, limit, offset, viewerID)
+	if err != nil {
+		return nil, err
+	}
+	return r.scanPostRows(rows, true)
 }

--- a/backend/internal/service/post_service.go
+++ b/backend/internal/service/post_service.go
@@ -19,6 +19,9 @@ type PostService interface {
 	GetPosts(ctx context.Context, userID *uuid.UUID) ([]dto.PostDetailResponse, error)
 	CreateReply(ctx context.Context, parentID, authorID uuid.UUID, req dto.CreateReplyRequest) (*dto.PostDetailResponse, error)
 	ListReplies(ctx context.Context, parentID uuid.UUID, userID *uuid.UUID) ([]dto.PostDetailResponse, error)
+	ListPostsByHandle(ctx context.Context, handle string, viewerID *uuid.UUID) ([]dto.PostDetailResponse, error)
+	ListRepliesByHandle(ctx context.Context, handle string, viewerID *uuid.UUID) ([]dto.PostDetailResponse, error)
+	ListLikedPostsByHandle(ctx context.Context, handle string, viewerID *uuid.UUID) ([]dto.PostDetailResponse, error)
 }
 
 const maxAuthorThreadDepth = 10
@@ -283,4 +286,63 @@ func (s *postService) ListReplies(ctx context.Context, parentID uuid.UUID, userI
 		responses[i] = dto.ToPostDetailResponse(r)
 	}
 	return responses, nil
+}
+
+func (s *postService) toPostDetailResponses(posts []model.PostWithAuthor) []dto.PostDetailResponse {
+	responses := make([]dto.PostDetailResponse, len(posts))
+	for i, p := range posts {
+		responses[i] = dto.ToPostDetailResponse(p)
+	}
+	return responses
+}
+
+func (s *postService) ListPostsByHandle(ctx context.Context, handle string, viewerID *uuid.UUID) ([]dto.PostDetailResponse, error) {
+	var posts []model.PostWithAuthor
+	var err error
+
+	if viewerID != nil {
+		posts, err = s.postRepo.FindByAuthorHandleWithUser(ctx, handle, 50, 0, *viewerID)
+	} else {
+		posts, err = s.postRepo.FindByAuthorHandle(ctx, handle, 50, 0)
+	}
+
+	if err != nil {
+		return nil, apperror.Internal("failed to retrieve user posts")
+	}
+
+	return s.toPostDetailResponses(posts), nil
+}
+
+func (s *postService) ListRepliesByHandle(ctx context.Context, handle string, viewerID *uuid.UUID) ([]dto.PostDetailResponse, error) {
+	var posts []model.PostWithAuthor
+	var err error
+
+	if viewerID != nil {
+		posts, err = s.postRepo.FindRepliesByAuthorHandleWithUser(ctx, handle, 50, 0, *viewerID)
+	} else {
+		posts, err = s.postRepo.FindRepliesByAuthorHandle(ctx, handle, 50, 0)
+	}
+
+	if err != nil {
+		return nil, apperror.Internal("failed to retrieve user replies")
+	}
+
+	return s.toPostDetailResponses(posts), nil
+}
+
+func (s *postService) ListLikedPostsByHandle(ctx context.Context, handle string, viewerID *uuid.UUID) ([]dto.PostDetailResponse, error) {
+	var posts []model.PostWithAuthor
+	var err error
+
+	if viewerID != nil {
+		posts, err = s.postRepo.FindLikedByUserHandleWithViewer(ctx, handle, 50, 0, *viewerID)
+	} else {
+		posts, err = s.postRepo.FindLikedByUserHandle(ctx, handle, 50, 0)
+	}
+
+	if err != nil {
+		return nil, apperror.Internal("failed to retrieve liked posts")
+	}
+
+	return s.toPostDetailResponses(posts), nil
 }

--- a/backend/internal/service/post_service_test.go
+++ b/backend/internal/service/post_service_test.go
@@ -99,6 +99,30 @@ func (m *mockPostRepo) FindAuthorReplyByPostIDWithUser(_ context.Context, postID
 	return m.FindAuthorReplyByPostID(context.Background(), postID, authorID)
 }
 
+func (m *mockPostRepo) FindByAuthorHandle(_ context.Context, _ string, _, _ int) ([]model.PostWithAuthor, error) {
+	return nil, nil
+}
+
+func (m *mockPostRepo) FindByAuthorHandleWithUser(_ context.Context, _ string, _, _ int, _ uuid.UUID) ([]model.PostWithAuthor, error) {
+	return nil, nil
+}
+
+func (m *mockPostRepo) FindRepliesByAuthorHandle(_ context.Context, _ string, _, _ int) ([]model.PostWithAuthor, error) {
+	return nil, nil
+}
+
+func (m *mockPostRepo) FindRepliesByAuthorHandleWithUser(_ context.Context, _ string, _, _ int, _ uuid.UUID) ([]model.PostWithAuthor, error) {
+	return nil, nil
+}
+
+func (m *mockPostRepo) FindLikedByUserHandle(_ context.Context, _ string, _, _ int) ([]model.PostWithAuthor, error) {
+	return nil, nil
+}
+
+func (m *mockPostRepo) FindLikedByUserHandleWithViewer(_ context.Context, _ string, _, _ int, _ uuid.UUID) ([]model.PostWithAuthor, error) {
+	return nil, nil
+}
+
 func TestCreatePost_Success(t *testing.T) {
 	repo := newMockPostRepo()
 	svc := NewPostService(repo)

--- a/backend/main.go
+++ b/backend/main.go
@@ -48,7 +48,7 @@ func main() {
 	followHandler := handler.NewFollowHandler(followService)
 
 	userService := service.NewUserService(userRepo, followRepo)
-	userHandler := handler.NewUserHandler(userService)
+	userHandler := handler.NewUserHandler(userService, postService)
 
 	api := app.Group("/api")
 	posts := api.Group("/posts")
@@ -72,6 +72,9 @@ func main() {
 	users.Delete("/:handle/follow", middleware.AuthRequired(cfg.JWTSecret), followHandler.Unfollow)
 	users.Get("/:handle/following", followHandler.GetFollowing)
 	users.Get("/:handle/followers", followHandler.GetFollowers)
+	users.Get("/:handle/posts", middleware.OptionalAuth(cfg.JWTSecret), userHandler.GetUserPosts)
+	users.Get("/:handle/replies", middleware.OptionalAuth(cfg.JWTSecret), userHandler.GetUserReplies)
+	users.Get("/:handle/likes", middleware.OptionalAuth(cfg.JWTSecret), userHandler.GetUserLikes)
 	users.Get("/:handle", middleware.OptionalAuth(cfg.JWTSecret), userHandler.GetProfile)
 
 	log.Fatal(app.Listen(":8080"))

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -32,3 +32,11 @@
 - 답글에도 좋아요/답글 달기 등 동일 인터랙션 적용 가능
 - 별도 테이블 대비 JOIN 복잡도 감소
 **트레이드오프**: N-depth 지원 가능하지만, UI 복잡도 관리를 위해 1-depth만 렌더링. 피드 쿼리에 `WHERE parent_id IS NULL` 필터 필요
+
+## 2026-03-06 — Profile 탭 조회: handle 기반 Repository 메서드
+**상황**: Profile 페이지에서 사용자 게시물/답글/좋아요를 조회할 때 handle(username)로 API를 호출
+**결정**: PostRepository에 handle 기반 조회 메서드 추가 (users JOIN으로 username → author_id 해석)
+**이유**:
+- 프론트엔드에서 handle만 알고 있으므로 별도 user ID 조회 단계 없이 한 번의 쿼리로 해결
+- 좋아요 목록은 likes 테이블 + users(target) + posts + users(author) 4-way JOIN
+**트레이드오프**: Repository 메서드 수 증가 (6개), 하지만 각각 단일 쿼리로 N+1 없음

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -47,7 +47,16 @@
 - [x] LoginPage/RegisterPage shadcn/ui 마이그레이션
 - [x] formatRelativeTime 유틸리티 함수
 
+## Phase 7: Profile 탭 콘텐츠 (완료)
+- [x] PostRepository handle 기반 조회 메서드 6개 추가 (#31)
+- [x] PostService 3개 조회 메서드 (ListPostsByHandle, ListRepliesByHandle, ListLikedPostsByHandle)
+- [x] UserHandler PostService 의존성 + 핸들러 3개 (GetUserPosts, GetUserReplies, GetUserLikes)
+- [x] main.go 라우트 3개 등록 (OptionalAuth)
+- [x] useUserPosts.ts hook (useUserPosts, useUserReplies, useUserLikes)
+- [x] ProfilePage.tsx 탭 콘텐츠 실제 데이터 연동 (PostCard 렌더링, 로딩/빈 상태)
+
 ## 최근 변경 로그
+- 2026-03-06: 이슈 #31 Profile 페이지 탭 콘텐츠 구현 (게시물/답글/좋아요)
 - 2026-03-06: 이슈 #19 주요 UI 레이아웃 및 스타일링 고도화 (3단 레이아웃, 반응형)
 - 2026-03-06: 이슈 #18 shadcn/ui 기반 공통 UI 컴포넌트 시스템 구축
 - 2026-03-05: 이슈 #28 Post Detail API nested replies 최적화 (110+→1 요청)

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -123,6 +123,27 @@ function PostCard({ post }: PostCardProps) {
             )}
           </div>
 
+          {/* Replying to context */}
+          {post.parent && (
+            <div
+              className="mt-0.5 flex items-center gap-1 text-[13px] text-muted-foreground"
+              onClick={(e) => {
+                e.stopPropagation();
+                navigate(`/post/${post.parent!.id}`);
+              }}
+            >
+              <span>
+                <span className="text-muted-foreground">replying to </span>
+                <span className="cursor-pointer text-primary hover:underline">
+                  @{post.parent.author.username}
+                </span>
+              </span>
+              <span className="truncate text-muted-foreground/70">
+                — {post.parent.content}
+              </span>
+            </div>
+          )}
+
           {/* Content */}
           <p className="mt-0.5 text-[15px] leading-normal text-foreground">
             {post.content}

--- a/frontend/src/hooks/useUserPosts.ts
+++ b/frontend/src/hooks/useUserPosts.ts
@@ -1,0 +1,53 @@
+import { useQuery } from "@tanstack/react-query";
+import type { APIResponse, PostDetail } from "@/types/api";
+
+async function fetchUserPosts(handle: string): Promise<PostDetail[]> {
+  const res = await fetch(`/api/users/${handle}/posts`);
+  const json: APIResponse<PostDetail[]> = await res.json();
+  if (!json.success) {
+    throw new Error(json.error ?? "Failed to fetch user posts");
+  }
+  return json.data;
+}
+
+async function fetchUserReplies(handle: string): Promise<PostDetail[]> {
+  const res = await fetch(`/api/users/${handle}/replies`);
+  const json: APIResponse<PostDetail[]> = await res.json();
+  if (!json.success) {
+    throw new Error(json.error ?? "Failed to fetch user replies");
+  }
+  return json.data;
+}
+
+async function fetchUserLikes(handle: string): Promise<PostDetail[]> {
+  const res = await fetch(`/api/users/${handle}/likes`);
+  const json: APIResponse<PostDetail[]> = await res.json();
+  if (!json.success) {
+    throw new Error(json.error ?? "Failed to fetch user likes");
+  }
+  return json.data;
+}
+
+export function useUserPosts(handle: string) {
+  return useQuery({
+    queryKey: ["users", handle, "posts"],
+    queryFn: () => fetchUserPosts(handle),
+    enabled: !!handle,
+  });
+}
+
+export function useUserReplies(handle: string) {
+  return useQuery({
+    queryKey: ["users", handle, "replies"],
+    queryFn: () => fetchUserReplies(handle),
+    enabled: !!handle,
+  });
+}
+
+export function useUserLikes(handle: string) {
+  return useQuery({
+    queryKey: ["users", handle, "likes"],
+    queryFn: () => fetchUserLikes(handle),
+    enabled: !!handle,
+  });
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,11 +1,19 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import type { UseQueryResult } from "@tanstack/react-query";
 import { ArrowLeft, CalendarDays } from "lucide-react";
+import type { PostDetail } from "@/types/api";
 import { useProfile } from "@/hooks/useProfile";
 import { useAuth } from "@/hooks/useAuthContext";
 import { useFollow, useUnfollow } from "@/hooks/useFollow";
+import {
+  useUserPosts,
+  useUserReplies,
+  useUserLikes,
+} from "@/hooks/useUserPosts";
 import EditProfileModal from "@/components/EditProfileModal";
 import FollowListModal from "@/components/FollowListModal";
+import PostCard from "@/components/PostCard";
 import UserAvatar from "@/components/UserAvatar";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -26,6 +34,9 @@ export default function ProfilePage() {
 
   const follow = useFollow(handle ?? "");
   const unfollow = useUnfollow(handle ?? "");
+  const userPosts = useUserPosts(handle ?? "");
+  const userReplies = useUserReplies(handle ?? "");
+  const userLikes = useUserLikes(handle ?? "");
 
   const isOwner = currentUser?.username === profile?.username;
 
@@ -89,7 +100,9 @@ export default function ProfilePage() {
           <div className="text-xl font-bold leading-tight">
             {profile.displayName}
           </div>
-          <div className="text-[13px] text-muted-foreground">0 posts</div>
+          <div className="text-[13px] text-muted-foreground">
+            {userPosts.data?.length ?? 0} posts
+          </div>
         </div>
       </header>
 
@@ -209,11 +222,12 @@ export default function ProfilePage() {
       </div>
 
       {/* Tab Content */}
-      <div className="py-8 text-center text-sm text-muted-foreground">
-        {activeTab === "posts" && "아직 게시물이 없습니다."}
-        {activeTab === "replies" && "아직 답글이 없습니다."}
-        {activeTab === "likes" && "아직 좋아요한 게시물이 없습니다."}
-      </div>
+      <TabContent
+        tab={activeTab}
+        userPosts={userPosts}
+        userReplies={userReplies}
+        userLikes={userLikes}
+      />
 
       {showEditModal && currentUser && (
         <EditProfileModal
@@ -230,5 +244,54 @@ export default function ProfilePage() {
         />
       )}
     </>
+  );
+}
+
+function TabContent({
+  tab,
+  userPosts,
+  userReplies,
+  userLikes,
+}: {
+  tab: Tab;
+  userPosts: UseQueryResult<PostDetail[]>;
+  userReplies: UseQueryResult<PostDetail[]>;
+  userLikes: UseQueryResult<PostDetail[]>;
+}) {
+  const queryMap = {
+    posts: userPosts,
+    replies: userReplies,
+    likes: userLikes,
+  };
+  const emptyMessages = {
+    posts: "아직 게시물이 없습니다.",
+    replies: "아직 답글이 없습니다.",
+    likes: "아직 좋아요한 게시물이 없습니다.",
+  };
+
+  const { data, isLoading } = queryMap[tab];
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="py-8 text-center text-sm text-muted-foreground">
+        {emptyMessages[tab]}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {data.map((post) => (
+        <PostCard key={post.id} post={post} />
+      ))}
+    </div>
   );
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -86,10 +86,17 @@ export interface PostAuthor {
   profileImageUrl: string
 }
 
+export interface ParentPostSummary {
+  id: string
+  content: string
+  author: PostAuthor
+}
+
 export interface PostDetail {
   id: string
   authorId: string
   parentId: string | null
+  parent?: ParentPostSummary | null
   content: string
   visibility: 'public' | 'friends' | 'private'
   author: PostAuthor


### PR DESCRIPTION
## 📄 개요

> Profile 페이지의 3개 탭(게시물/답글/좋아요)에서 실제 데이터를 조회하여 PostCard로 렌더링합니다. 답글 탭에서는 부모 게시물 컨텍스트(작성자 + 콘텐츠 미리보기)를 함께 표시하고, 헤더의 하드코딩된 "0 posts"를 실제 게시물 수로 교체합니다.

<br>

## 🔨 해야 할 일

- [x] `PostRepository`: handle 기반 조회 메서드 6개 추가 (게시물/답글/좋아요 × WithUser)
- [x] `PostService`: `ListPostsByHandle`, `ListRepliesByHandle`, `ListLikedPostsByHandle` 메서드
- [x] `UserHandler`: `PostService` 의존성 추가 + 핸들러 3개 (GetUserPosts, GetUserReplies, GetUserLikes)
- [x] `main.go`: `GET /api/users/:handle/posts|replies|likes` 라우트 등록 (OptionalAuth)
- [x] 답글 쿼리에 `LEFT JOIN`으로 부모 게시물 정보 포함 (`ParentPostSummary` DTO)
- [x] `useUserPosts.ts` hook 생성 (`useUserPosts`, `useUserReplies`, `useUserLikes`)
- [x] `ProfilePage.tsx` 탭 콘텐츠를 실제 데이터로 연동 (PostCard 렌더링, 로딩/빈 상태)
- [x] `PostCard.tsx` 부모 컨텍스트 표시 ("replying to @username — 미리보기")
- [x] 프로필 헤더 "0 posts" → 실제 게시물 수 표시

<br>

## 🙋🏻 덧붙일 말

- 답글 탭에서 부모 정보를 가져오기 위해 `LEFT JOIN posts pp + users pu`를 사용했습니다. 추가 API 호출 없이 단일 쿼리로 해결합니다.
- 기존 테스트의 mock에 새 인터페이스 메서드 stub을 추가하여 테스트 통과를 유지했습니다.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)