### PR TITLE
feat: enhance reply with media, location, poll and fix interactions

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -89,7 +89,10 @@ type PostDetailResponse struct {
 }
 
 type CreateReplyRequest struct {
-	Content string `json:"content" validate:"required,min=1,max=500"`
+	Content  string           `json:"content"  validate:"required,min=1,max=500"`
+	MediaIds []string         `json:"mediaIds" validate:"omitempty,max=4"`
+	Location *LocationRequest `json:"location"`
+	Poll     *PollRequest     `json:"poll"`
 }
 
 func ToPostResponse(p model.Post) PostResponse {

--- a/backend/internal/repository/post_repository.go
+++ b/backend/internal/repository/post_repository.go
@@ -27,6 +27,7 @@ type PostRepository interface {
 	FindLikedByUserHandle(ctx context.Context, handle string, limit, offset int) ([]model.PostWithAuthor, error)
 	FindLikedByUserHandleWithViewer(ctx context.Context, handle string, limit, offset int, viewerID uuid.UUID) ([]model.PostWithAuthor, error)
 	IncrementViewCount(ctx context.Context, id uuid.UUID) error
+	IncrementViewCountBatch(ctx context.Context, ids []uuid.UUID) error
 }
 
 type postRepository struct {
@@ -549,6 +550,17 @@ func (r *postRepository) IncrementViewCount(ctx context.Context, id uuid.UUID) e
 	_, err := r.pool.Exec(ctx, `UPDATE posts SET view_count = view_count + 1 WHERE id = $1`, id)
 	if err != nil {
 		return fmt.Errorf("failed to increment view count: %w", err)
+	}
+	return nil
+}
+
+func (r *postRepository) IncrementViewCountBatch(ctx context.Context, ids []uuid.UUID) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	_, err := r.pool.Exec(ctx, `UPDATE posts SET view_count = view_count + 1 WHERE id = ANY($1)`, ids)
+	if err != nil {
+		return fmt.Errorf("failed to batch increment view count: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/service/bookmark_service_test.go
+++ b/backend/internal/service/bookmark_service_test.go
@@ -93,6 +93,10 @@ func (m *mockPostRepoForBookmark) IncrementViewCount(_ context.Context, _ uuid.U
 	return nil
 }
 
+func (m *mockPostRepoForBookmark) IncrementViewCountBatch(_ context.Context, _ []uuid.UUID) error {
+	return nil
+}
+
 func TestBookmark(t *testing.T) {
 	existingPostID := uuid.New()
 	userID := uuid.New()

--- a/backend/internal/service/poll_service_test.go
+++ b/backend/internal/service/poll_service_test.go
@@ -102,6 +102,10 @@ func (m *mockPostRepoForPoll) IncrementViewCount(_ context.Context, _ uuid.UUID)
 	return nil
 }
 
+func (m *mockPostRepoForPoll) IncrementViewCountBatch(_ context.Context, _ []uuid.UUID) error {
+	return nil
+}
+
 // --- Tests ---
 
 func TestPollService_Vote(t *testing.T) {

--- a/backend/internal/service/post_service.go
+++ b/backend/internal/service/post_service.go
@@ -207,6 +207,8 @@ func (s *postService) fetchReplies(ctx context.Context, postID uuid.UUID, userID
 		return nil, err
 	}
 
+	s.incrementViewCounts(ctx, replies, userID)
+
 	responses := make([]dto.PostDetailResponse, len(replies))
 	for i, r := range replies {
 		responses[i] = dto.ToPostDetailResponse(r)
@@ -298,7 +300,13 @@ func (s *postService) GetPosts(ctx context.Context, userID *uuid.UUID) ([]dto.Po
 
 func (s *postService) CreateReply(ctx context.Context, parentID, authorID uuid.UUID, req dto.CreateReplyRequest) (*dto.PostDetailResponse, error) {
 	content := req.Content
-	if utf8.RuneCountInString(content) == 0 {
+	hasMedia := len(req.MediaIds) > 0
+
+	if req.Poll != nil && hasMedia {
+		return nil, apperror.BadRequest("poll and media cannot be used together")
+	}
+
+	if utf8.RuneCountInString(content) == 0 && !hasMedia {
 		return nil, apperror.BadRequest("content must not be empty")
 	}
 	if utf8.RuneCountInString(content) > 500 {
@@ -320,8 +328,50 @@ func (s *postService) CreateReply(ctx context.Context, parentID, authorID uuid.U
 		Visibility: model.VisibilityPublic,
 	}
 
+	if req.Location != nil {
+		post.LocationLat = &req.Location.Latitude
+		post.LocationLng = &req.Location.Longitude
+		if req.Location.Name != "" {
+			post.LocationName = &req.Location.Name
+		}
+	}
+
 	if err := s.postRepo.CreateReply(ctx, post); err != nil {
 		return nil, apperror.Internal("failed to create reply")
+	}
+
+	if len(req.MediaIds) > 0 {
+		var mediaIDs []uuid.UUID
+		for _, idStr := range req.MediaIds {
+			id, err := uuid.Parse(idStr)
+			if err != nil {
+				return nil, apperror.BadRequest("invalid media ID: %s", idStr)
+			}
+			mediaIDs = append(mediaIDs, id)
+		}
+		if err := s.mediaRepo.LinkToPost(ctx, mediaIDs, post.ID); err != nil {
+			return nil, apperror.Internal("failed to link media to reply")
+		}
+	}
+
+	if req.Poll != nil {
+		expiresAt := time.Now().Add(time.Duration(req.Poll.DurationMinutes) * time.Minute)
+		poll := &model.Poll{
+			PostID:    post.ID,
+			ExpiresAt: expiresAt,
+		}
+
+		var options []model.PollOption
+		for i, text := range req.Poll.Options {
+			options = append(options, model.PollOption{
+				OptionIndex: int16(i),
+				Text:        text,
+			})
+		}
+
+		if err := s.pollRepo.CreatePoll(ctx, poll, options); err != nil {
+			return nil, apperror.Internal("failed to create poll")
+		}
 	}
 
 	result, err := s.postRepo.FindByID(ctx, post.ID)
@@ -330,6 +380,7 @@ func (s *postService) CreateReply(ctx context.Context, parentID, authorID uuid.U
 	}
 
 	resp := dto.ToPostDetailResponse(*result)
+	_ = s.enrichWithPollAndMedia(ctx, &resp, nil)
 	return &resp, nil
 }
 
@@ -353,6 +404,8 @@ func (s *postService) ListReplies(ctx context.Context, parentID uuid.UUID, userI
 	if err != nil {
 		return nil, apperror.Internal("failed to retrieve replies")
 	}
+
+	s.incrementViewCounts(ctx, replies, userID)
 
 	responses := make([]dto.PostDetailResponse, len(replies))
 	for i, r := range replies {
@@ -421,6 +474,27 @@ func (s *postService) enrichWithPollAndMedia(ctx context.Context, resp *dto.Post
 	}
 
 	return nil
+}
+
+func (s *postService) incrementViewCounts(ctx context.Context, posts []model.PostWithAuthor, userID *uuid.UUID) {
+	var ids []uuid.UUID
+	for i := range posts {
+		if userID == nil || posts[i].AuthorID != *userID {
+			ids = append(ids, posts[i].ID)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	if err := s.postRepo.IncrementViewCountBatch(ctx, ids); err != nil {
+		slog.Error("failed to batch increment view count", "error", err)
+		return
+	}
+	for i := range posts {
+		if userID == nil || posts[i].AuthorID != *userID {
+			posts[i].ViewCount++
+		}
+	}
 }
 
 func (s *postService) enrichSlice(ctx context.Context, responses []dto.PostDetailResponse, userID *uuid.UUID) {

--- a/backend/internal/service/post_service_test.go
+++ b/backend/internal/service/post_service_test.go
@@ -127,6 +127,10 @@ func (m *mockPostRepo) IncrementViewCount(_ context.Context, _ uuid.UUID) error 
 	return nil
 }
 
+func (m *mockPostRepo) IncrementViewCountBatch(_ context.Context, _ []uuid.UUID) error {
+	return nil
+}
+
 type mockPollRepo struct{}
 
 func newMockPollRepo() *mockPollRepo {

--- a/frontend/src/components/ReplyCard.tsx
+++ b/frontend/src/components/ReplyCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Eye, Heart, MessageCircle } from "lucide-react";
 import type { PostDetail } from "@/types/api";
@@ -7,7 +6,6 @@ import { useLike } from "@/hooks/useLike";
 import ProfileHoverCard from "@/components/ProfileHoverCard";
 import UserAvatar from "@/components/UserAvatar";
 import MarkdownRenderer from "@/components/MarkdownRenderer";
-import ReplyForm from "@/components/ReplyForm";
 import { formatCompactNumber } from "@/lib/formatTime";
 import { cn } from "@/lib/utils";
 
@@ -27,7 +25,6 @@ export default function ReplyCard({
   const navigate = useNavigate();
   const { user: currentUser } = useAuth();
   const like = useLike(reply.id, reply.isLiked, parentPostId);
-  const [showReplyForm, setShowReplyForm] = useState(false);
 
   const authorThread = reply.topReplies ?? [];
   const hasContinuation = authorThread.length > 0;
@@ -40,10 +37,10 @@ export default function ReplyCard({
     like.mutate();
   }
 
-  function handleReplyToggle(e: React.MouseEvent) {
+  function handleReplyClick(e: React.MouseEvent) {
     e.stopPropagation();
     if (!currentUser) return;
-    setShowReplyForm((prev) => !prev);
+    navigate(`/compose?replyTo=${reply.id}`);
   }
 
   function handleCardClick() {
@@ -137,7 +134,7 @@ export default function ReplyCard({
               </span>
             </button>
             <button
-              onClick={handleReplyToggle}
+              onClick={handleReplyClick}
               className="group flex cursor-pointer items-center gap-1 border-none bg-transparent p-0"
             >
               <MessageCircle
@@ -157,10 +154,6 @@ export default function ReplyCard({
           </div>
         </div>
       </div>
-
-      {showReplyForm && (
-        <ReplyForm postId={reply.id} parentPostId={parentPostId} />
-      )}
 
       {authorThread.map((continuation, index) => (
         <ReplyCard

--- a/frontend/src/components/ReplyForm.tsx
+++ b/frontend/src/components/ReplyForm.tsx
@@ -1,9 +1,14 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
+import { Image, MapPin, BarChart3 } from "lucide-react";
 import { useCreateReply } from "@/hooks/useReplies";
+import { useMediaUpload } from "@/hooks/useMediaUpload";
+import { useGeolocation } from "@/hooks/useGeolocation";
 import { toast } from "sonner";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import MediaPreview from "@/components/MediaPreview";
+import PollCreator from "@/components/PollCreator";
 
 const MAX_LENGTH = 500;
 
@@ -15,25 +20,116 @@ interface ReplyFormProps {
 export default function ReplyForm({ postId, parentPostId }: ReplyFormProps) {
   const [content, setContent] = useState("");
   const { mutate, isPending } = useCreateReply(postId, parentPostId);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { uploads, mediaItems, isUploading, addFiles, removeMedia, reset } =
+    useMediaUpload();
+
+  const {
+    location,
+    isLoading: isLocationLoading,
+    error: locationError,
+    requestLocation,
+    clearLocation,
+  } = useGeolocation();
+
+  const [showPoll, setShowPoll] = useState(false);
+  const [pollOptions, setPollOptions] = useState(["", ""]);
+  const [pollDuration, setPollDuration] = useState(1440);
 
   const remaining = MAX_LENGTH - [...content].length;
 
+  useEffect(() => {
+    if (locationError) {
+      toast.error(locationError);
+    }
+  }, [locationError]);
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (remaining < 0 || content.trim().length === 0 || isPending) return;
+    if (remaining < 0 || isPending || isUploading) return;
+    if (content.trim().length === 0 && mediaItems.length === 0) return;
+
+    if (showPoll) {
+      const filledOptions = pollOptions.filter((o) => o.trim().length > 0);
+      if (filledOptions.length < 2) {
+        toast.error("최소 2개의 선택지를 입력해주세요.");
+        return;
+      }
+    }
 
     mutate(
-      { content },
+      {
+        content,
+        mediaIds:
+          mediaItems.length > 0 ? mediaItems.map((m) => m.id) : undefined,
+        location: location
+          ? {
+              latitude: location.latitude,
+              longitude: location.longitude,
+              name: location.name,
+            }
+          : undefined,
+        poll: showPoll
+          ? {
+              options: pollOptions.filter((o) => o.trim().length > 0),
+              durationMinutes: pollDuration,
+            }
+          : undefined,
+      },
       {
         onSuccess: () => {
           setContent("");
+          reset();
+          clearLocation();
+          setShowPoll(false);
+          setPollOptions(["", ""]);
+          setPollDuration(1440);
           toast.success("댓글이 작성되었습니다.");
         },
         onError: (err) => {
-          toast.error("댓글 작성에 실패했습니다.", { description: err.message });
+          toast.error("댓글 작성에 실패했습니다.", {
+            description: err.message,
+          });
         },
       },
     );
+  }
+
+  async function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? []);
+    if (files.length === 0) return;
+    const error = await addFiles(files);
+    if (error) toast.error(error);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  function handleMediaButtonClick() {
+    if (showPoll) {
+      toast.error("투표와 미디어는 동시에 첨부할 수 없습니다.");
+      return;
+    }
+    fileInputRef.current?.click();
+  }
+
+  function handlePollToggle() {
+    if (mediaItems.length > 0) {
+      toast.error("미디어와 투표는 동시에 첨부할 수 없습니다.");
+      return;
+    }
+    setShowPoll(!showPoll);
+    if (!showPoll) {
+      setPollOptions(["", ""]);
+      setPollDuration(1440);
+    }
+  }
+
+  function handleLocationClick() {
+    if (location) {
+      clearLocation();
+    } else {
+      requestLocation();
+    }
   }
 
   return (
@@ -46,24 +142,105 @@ export default function ReplyForm({ postId, parentPostId }: ReplyFormProps) {
         maxLength={MAX_LENGTH}
         rows={2}
       />
-      <div className="flex items-center justify-end gap-3 border-t border-border pt-2">
-        <span
-          className={cn(
-            "text-sm text-muted-foreground",
-            remaining < 0 && "text-destructive",
-            remaining >= 0 && remaining <= 20 && "text-warning",
-          )}
-        >
-          {remaining}
-        </span>
-        <Button
-          type="submit"
-          size="sm"
-          className="rounded-full"
-          disabled={remaining < 0 || content.trim().length === 0 || isPending}
-        >
-          {isPending ? "Replying..." : "Reply"}
-        </Button>
+
+      {/* Media preview */}
+      <MediaPreview
+        uploads={uploads}
+        mediaItems={mediaItems}
+        onRemove={removeMedia}
+      />
+
+      {/* Poll creator */}
+      {showPoll && (
+        <PollCreator
+          options={pollOptions}
+          durationMinutes={pollDuration}
+          onOptionsChange={setPollOptions}
+          onDurationChange={setPollDuration}
+          onRemove={() => setShowPoll(false)}
+        />
+      )}
+
+      {/* Location tag */}
+      {location && (
+        <div className="mt-2 flex items-center gap-1.5 text-[13px] text-primary">
+          <MapPin size={14} />
+          <span>{location.name}</span>
+          <button
+            type="button"
+            onClick={clearLocation}
+            className="cursor-pointer rounded-full border-none bg-transparent p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            x
+          </button>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between border-t border-border pt-2">
+        <div className="flex items-center gap-1">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm"
+            multiple
+            onChange={handleFileSelect}
+            className="hidden"
+          />
+          <button
+            type="button"
+            onClick={handleMediaButtonClick}
+            className="cursor-pointer rounded-full border-none bg-transparent p-1.5 text-primary/70 transition-colors hover:bg-primary/10 hover:text-primary"
+            title="미디어 첨부"
+          >
+            <Image size={16} />
+          </button>
+          <button
+            type="button"
+            onClick={handleLocationClick}
+            disabled={isLocationLoading}
+            className={`cursor-pointer rounded-full border-none bg-transparent p-1.5 transition-colors hover:bg-primary/10 ${
+              location ? "text-primary" : "text-primary/70 hover:text-primary"
+            } disabled:opacity-50`}
+            title="위치 추가"
+          >
+            <MapPin size={16} />
+          </button>
+          <button
+            type="button"
+            onClick={handlePollToggle}
+            className={`cursor-pointer rounded-full border-none bg-transparent p-1.5 transition-colors hover:bg-primary/10 ${
+              showPoll ? "text-primary" : "text-primary/70 hover:text-primary"
+            }`}
+            title="투표 만들기"
+          >
+            <BarChart3 size={16} />
+          </button>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <span
+            className={cn(
+              "text-sm text-muted-foreground",
+              remaining < 0 && "text-destructive",
+              remaining >= 0 && remaining <= 20 && "text-warning",
+            )}
+          >
+            {remaining}
+          </span>
+          <Button
+            type="submit"
+            size="sm"
+            className="rounded-full"
+            disabled={
+              remaining < 0 ||
+              (content.trim().length === 0 && mediaItems.length === 0) ||
+              isPending ||
+              isUploading
+            }
+          >
+            {isPending ? "Replying..." : "Reply"}
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/frontend/src/hooks/useLike.ts
+++ b/frontend/src/hooks/useLike.ts
@@ -20,6 +20,21 @@ async function deleteLike(postId: string): Promise<LikeStatusResponse> {
   return json.data;
 }
 
+function updateNestedReplies(
+  replies: PostDetail[] | null,
+  targetId: string,
+  liked: boolean,
+): PostDetail[] | null {
+  if (!replies) return replies;
+  return replies.map((r) => {
+    if (r.id === targetId) return updatePostInCache(r, liked);
+    if (r.topReplies) {
+      return { ...r, topReplies: updateNestedReplies(r.topReplies, targetId, liked) };
+    }
+    return r;
+  });
+}
+
 function updatePostInCache(old: PostDetail, liked: boolean): PostDetail {
   return {
     ...old,
@@ -74,7 +89,21 @@ export function useLike(postId: string, isLiked: boolean, parentId?: string) {
         );
       }
 
-      return { prevPosts, prevPost, prevReplies };
+      const prevParent = parentId
+        ? queryClient.getQueryData<PostDetail>(["post", parentId])
+        : undefined;
+
+      if (parentId && prevParent?.topReplies) {
+        queryClient.setQueryData<PostDetail>(["post", parentId], (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            topReplies: updateNestedReplies(old.topReplies, postId, nextLiked),
+          };
+        });
+      }
+
+      return { prevPosts, prevPost, prevReplies, prevParent };
     },
     onError: (_err, _vars, context) => {
       if (context?.prevPosts) {
@@ -89,11 +118,15 @@ export function useLike(postId: string, isLiked: boolean, parentId?: string) {
           context.prevReplies,
         );
       }
+      if (parentId && context?.prevParent) {
+        queryClient.setQueryData(["post", parentId], context.prevParent);
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["posts"] });
       queryClient.invalidateQueries({ queryKey: ["post", postId] });
       if (parentId) {
+        queryClient.invalidateQueries({ queryKey: ["post", parentId] });
         queryClient.invalidateQueries({
           queryKey: ["post", parentId, "replies"],
         });

--- a/frontend/src/pages/ComposePage.tsx
+++ b/frontend/src/pages/ComposePage.tsx
@@ -43,13 +43,8 @@ export default function ComposePage() {
     replyToId ?? "",
   );
 
-  const {
-    uploads,
-    mediaItems,
-    isUploading,
-    addFiles,
-    removeMedia,
-  } = useMediaUpload();
+  const { uploads, mediaItems, isUploading, addFiles, removeMedia } =
+    useMediaUpload();
 
   const {
     location,
@@ -93,8 +88,33 @@ export default function ComposePage() {
     if (!canSubmit) return;
 
     if (replyToId) {
+      if (showPoll) {
+        const filledOptions = pollOptions.filter((o) => o.trim().length > 0);
+        if (filledOptions.length < 2) {
+          toast.error("최소 2개의 선택지를 입력해주세요.");
+          return;
+        }
+      }
+
       createReply(
-        { content },
+        {
+          content,
+          mediaIds:
+            mediaItems.length > 0 ? mediaItems.map((m) => m.id) : undefined,
+          location: location
+            ? {
+                latitude: location.latitude,
+                longitude: location.longitude,
+                name: location.name,
+              }
+            : undefined,
+          poll: showPoll
+            ? {
+                options: pollOptions.filter((o) => o.trim().length > 0),
+                durationMinutes: pollDuration,
+              }
+            : undefined,
+        },
         {
           onSuccess: () => {
             toast.success("답글이 작성되었습니다.");
@@ -204,17 +224,13 @@ export default function ComposePage() {
           size="sm"
           disabled={!canSubmit}
         >
-          {isPending
-            ? "게시 중..."
-            : replyToId
-              ? "답글 작성"
-              : "게시하기"}
+          {isPending ? "게시 중..." : replyToId ? "답글 작성" : "게시하기"}
         </Button>
       </header>
 
       {/* Reply context */}
       {replyToId && parentPost && (
-        <div className="border-b border-border px-4 py-3">
+        <div className="border-border px-4 pt-3">
           <div className="flex gap-3">
             <div className="flex flex-col items-center">
               <UserAvatar
@@ -256,7 +272,7 @@ export default function ComposePage() {
       )}
 
       {/* Compose area */}
-      <div className="flex gap-3 px-4 pt-3">
+      <div className={`flex gap-3 px-4 ${!replyToId ? "pt-3" : ""}`}>
         <UserAvatar
           profileImageUrl={user?.profileImageUrl}
           displayName={user?.displayName}
@@ -273,9 +289,7 @@ export default function ComposePage() {
             ref={textareaRef}
             className="w-full resize-none border-none bg-transparent py-2 text-xl shadow-none focus-visible:ring-0 placeholder:text-muted-foreground"
             placeholder={
-              replyToId
-                ? "답글을 입력하세요..."
-                : "무슨 일이 일어나고 있나요?"
+              replyToId ? "답글을 입력하세요..." : "무슨 일이 일어나고 있나요?"
             }
             value={content}
             onChange={(e) => setContent(e.target.value)}
@@ -325,51 +339,47 @@ export default function ComposePage() {
           {/* Toolbar */}
           <div className="mt-2 flex items-center justify-between border-t border-border pt-2">
             <div className="flex items-center gap-1">
-              {!replyToId && (
-                <>
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    accept="image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm"
-                    multiple
-                    onChange={handleFileSelect}
-                    className="hidden"
-                  />
-                  <button
-                    type="button"
-                    onClick={handleMediaButtonClick}
-                    className="cursor-pointer rounded-full border-none bg-transparent p-2 text-primary/70 transition-colors hover:bg-primary/10 hover:text-primary"
-                    title="미디어 첨부"
-                  >
-                    <Image size={18} />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleLocationClick}
-                    disabled={isLocationLoading}
-                    className={`cursor-pointer rounded-full border-none bg-transparent p-2 transition-colors hover:bg-primary/10 ${
-                      location
-                        ? "text-primary"
-                        : "text-primary/70 hover:text-primary"
-                    } disabled:opacity-50`}
-                    title="위치 추가"
-                  >
-                    <MapPin size={18} />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handlePollToggle}
-                    className={`cursor-pointer rounded-full border-none bg-transparent p-2 transition-colors hover:bg-primary/10 ${
-                      showPoll
-                        ? "text-primary"
-                        : "text-primary/70 hover:text-primary"
-                    }`}
-                    title="투표 만들기"
-                  >
-                    <BarChart3 size={18} />
-                  </button>
-                </>
-              )}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm"
+                multiple
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+              <button
+                type="button"
+                onClick={handleMediaButtonClick}
+                className="cursor-pointer rounded-full border-none bg-transparent p-2 text-primary/70 transition-colors hover:bg-primary/10 hover:text-primary"
+                title="미디어 첨부"
+              >
+                <Image size={18} />
+              </button>
+              <button
+                type="button"
+                onClick={handleLocationClick}
+                disabled={isLocationLoading}
+                className={`cursor-pointer rounded-full border-none bg-transparent p-2 transition-colors hover:bg-primary/10 ${
+                  location
+                    ? "text-primary"
+                    : "text-primary/70 hover:text-primary"
+                } disabled:opacity-50`}
+                title="위치 추가"
+              >
+                <MapPin size={18} />
+              </button>
+              <button
+                type="button"
+                onClick={handlePollToggle}
+                className={`cursor-pointer rounded-full border-none bg-transparent p-2 transition-colors hover:bg-primary/10 ${
+                  showPoll
+                    ? "text-primary"
+                    : "text-primary/70 hover:text-primary"
+                }`}
+                title="투표 만들기"
+              >
+                <BarChart3 size={18} />
+              </button>
 
               {hasMarkdown && (
                 <button

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -155,6 +155,16 @@ export interface PostDetail {
 
 export interface CreateReplyRequest {
   content: string;
+  mediaIds?: string[];
+  location?: {
+    latitude: number;
+    longitude: number;
+    name?: string;
+  };
+  poll?: {
+    options: string[];
+    durationMinutes: number;
+  };
 }
 
 export interface LikeStatusResponse {


### PR DESCRIPTION
## 📄 개요

> 답글(Reply)에서도 일반 글 작성과 동일하게 미디어(사진/영상/GIF), 위치 태그, 투표를 첨부할 수 있도록 개선하고, 답글 관련 버그를 수정합니다.

<br>

## 🔨 해야 할 일

- [x] 백엔드 CreateReplyRequest에 mediaIds, location, poll 필드 추가
- [x] 백엔드 CreateReply 서비스에 미디어 링크/위치/투표 생성 로직 추가
- [x] 프론트엔드 ComposePage 답글 모드에서 미디어/위치/투표 버튼 활성화
- [x] 프론트엔드 ReplyForm에 미디어/위치/투표 UI 추가
- [x] 답글 목록 조회 시 X 방식 조회수 배치 집계 (IncrementViewCountBatch)
- [x] 답글 좋아요 시 부모 포스트 refetch 안되는 버그 수정
- [x] 답글 버튼 클릭 시 compose 페이지로 이동하도록 수정
- [x] 부모 글과 답글 작성 영역 시각적 연결 (border 제거)

<br>

## 🙋🏻 덧붙일 말

🤖 Generated with [Claude Code](https://claude.com/claude-code)