### PR TITLE
feat: 프로필 수정 모달 이미지 업로드 및 버튼 겹침 수정

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -71,3 +71,12 @@
 **결정**: `*string` 포인터 타입 + `ClearLocation`/`ClearPoll` boolean 플래그
 **이유**: Go JSON unmarshaling에서 `null` → `nil` 포인터, 필드 부재 → 포인터 그대로 nil 구분 가능
 **트레이드오프**: DTO 복잡도 증가, 하지만 정확한 의도 표현 가능
+
+## 2026-03-07 — Profile Modal 이미지 업로드 방식 (#51)
+**상황**: 프로필 수정 모달에서 이미지 URL 직접 입력 방식의 UX 불편, Dialog 닫기/저장 버튼 겹침
+**결정**: 기존 media upload API 재활용하여 파일 선택 → 업로드 → URL 자동 설정
+**이유**:
+- 백엔드 변경 없이 프론트엔드만 수정으로 해결 가능
+- 기존 `/api/media/upload` 엔드포인트와 완전 호환
+- X/Twitter와 동일한 인라인 이미지 선택 UX
+**트레이드오프**: 프로필 이미지도 post_media 테이블에 저장되어 용도 구분 없음 (현재 문제 아님)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -170,7 +170,16 @@
 - [x] 015_seed_data.down.sql (롤백)
 - [x] docker compose down -v && up 검증 완료
 
+## Phase 14: 프로필 수정 모달 개선 (#51) (완료)
+- [x] 스펙 문서 작성 (docs/specs/profile-modal-improvement-spec.md)
+- [x] 버튼 겹침 해결 (DialogHeader에 X 닫기 배치, 기본 닫기 버튼 숨김)
+- [x] 이미지 URL 입력 → 파일 업로드 UI 변경 (헤더/프로필 이미지)
+- [x] useUploadProfileImage 훅 분리 (useMutation + apiFetch)
+- [x] 코드 리뷰 Critical 2건 수정
+- [ ] PR 생성
+
 ## 최근 변경 로그
+- 2026-03-07: 이슈 #51 프로필 수정 모달 개선 - 파일 업로드, 버튼 겹침 수정
 - 2026-03-06: Seed Data 마이그레이션 + schema.md 최신화
 - 2026-03-06: Post/Reply 수정 및 삭제 구현 - soft delete, 인라인 편집, 권한 검증
 - 2026-03-06: 조회수(View Count) 시스템 구현 - 모든 post/reply에 조회수 표시, 큰 숫자 포맷팅

--- a/docs/reports/profile-modal-improvement-2026-03-07.md
+++ b/docs/reports/profile-modal-improvement-2026-03-07.md
@@ -1,0 +1,39 @@
+# Profile Modal Improvement Report
+
+**Issue**: #51
+**Branch**: feat/issue-51-profile-modal-upload
+**Date**: 2026-03-07
+
+## 변경 요약
+
+### 1. 버튼 겹침 수정
+- DialogContent의 기본 X 닫기 버튼을 CSS `[&>button:last-child]:hidden`으로 숨김
+- DialogHeader에 직접 X 닫기 버튼 배치 (좌측)
+- 레이아웃: `[X 닫기] [프로필 수정] ... [저장]`
+
+### 2. 이미지 파일 업로드
+- URL 텍스트 입력 필드 2개 제거
+- 헤더 배너 영역 클릭 -> 파일 선택 -> 업로드
+- 프로필 아바타 클릭 -> 파일 선택 -> 업로드
+- hover 시 Camera 아이콘 오버레이, 업로드 중 Loader2 스피너
+
+### 3. 코드 품질 개선 (리뷰 반영)
+- `uploadImage` raw fetch -> `useUploadProfileImage` 커스텀 훅 (useMutation + apiFetch)
+- 로딩 오버레이 중복 렌더링 제거
+- username 필드에 `maxLength={30}` 추가
+- form onSubmit 이중 호출 경로 제거
+
+## 변경 파일
+| 파일 | 변경 내용 |
+|------|-----------|
+| `frontend/src/components/EditProfileModal.tsx` | 전면 리팩토링 |
+| `frontend/src/hooks/useProfile.ts` | `useUploadProfileImage` 훅 추가 |
+| `docs/specs/profile-modal-improvement-spec.md` | 스펙 문서 |
+| `docs/TODO.md` | Phase 14 추가 |
+
+## 백엔드 변경
+없음. 기존 `/api/media/upload` + `PUT /api/users/profile` API 재활용.
+
+## 테스트
+- TypeScript 타입체크 + ESLint: PASS
+- 프론트엔드 단위 테스트 인프라 미구축 (별도 이슈 필요)

--- a/docs/specs/profile-modal-improvement-spec.md
+++ b/docs/specs/profile-modal-improvement-spec.md
@@ -1,0 +1,43 @@
+# Profile Modal Improvement Spec
+
+## 요약
+프로필 수정 모달의 이미지 삽입 방식을 URL 입력에서 직접 파일 업로드로 변경하고, 우측 상단 버튼 겹침 문제를 해결한다.
+
+## 문제 분석
+
+### 1. 이미지 삽입 방식
+- **현재**: URL 텍스트 입력 (`<Input type="url">`)
+- **문제**: 사용자가 외부 이미지 URL을 직접 알아야 함, UX 불편
+- **목표**: 파일 선택 → 업로드 → URL 자동 설정
+
+### 2. 버튼 겹침
+- **현재**: `DialogContent`가 `absolute right-4 top-4`에 X(닫기) 버튼 자동 렌더, `DialogHeader`에 "저장" 버튼이 우측 배치
+- **문제**: 닫기(X) 버튼과 저장 버튼이 같은 위치에 겹침
+- **목표**: 닫기 버튼을 DialogHeader 좌측으로 이동, 저장 버튼은 우측 유지
+
+## 구현 계획
+
+### Task 1: 버튼 겹침 해결
+**파일**: `frontend/src/components/EditProfileModal.tsx`
+- DialogHeader에 X 닫기 버튼을 직접 배치 (좌측)
+- DialogContent의 기본 X 버튼 숨기기 (빈 `<DialogClose>` 사용 또는 CSS로 숨김)
+- 레이아웃: `[X 닫기] [프로필 수정 타이틀] ... [저장 버튼]`
+
+### Task 2: 이미지 파일 업로드 UI
+**파일**: `frontend/src/components/EditProfileModal.tsx`
+- 기존 URL Input 2개 제거
+- 프로필 이미지: 아바타 클릭 → 파일 선택 → 업로드
+- 헤더 이미지: 배너 영역 클릭 → 파일 선택 → 업로드
+- 업로드 중 로딩 표시
+- 기존 `useMediaUpload` 훅의 `uploadFile` 로직 재활용 (단, 훅 전체가 아닌 업로드 API만 사용)
+
+### Task 3: 업로드 후 URL 설정
+- 미디어 업로드 성공 → 반환된 URL을 profileImageUrl/headerImageUrl state에 설정
+- 저장 시 기존 `useUpdateProfile` 그대로 사용 (URL 문자열로 서버에 전달)
+
+## 백엔드 변경 사항
+- **없음**: 기존 `/api/media/upload` 엔드포인트와 `PUT /api/users/profile` (URL 문자열) 그대로 활용
+
+## 영향 범위
+- `frontend/src/components/EditProfileModal.tsx` (주요 변경)
+- `frontend/src/components/ui/dialog.tsx` (변경 없음 - 모달별로 숨김 처리)

--- a/frontend/src/components/EditProfileModal.tsx
+++ b/frontend/src/components/EditProfileModal.tsx
@@ -1,68 +1,198 @@
-import { useState } from 'react'
-import { useUpdateProfile } from '@/hooks/useProfile'
-import { toast } from 'sonner'
-import type { User } from '@/types/api'
-import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
-import { Label } from '@/components/ui/label'
-import { Button } from '@/components/ui/button'
+import { useRef } from "react";
+import { useUpdateProfile, useUploadProfileImage } from "@/hooks/useProfile";
+import { toast } from "sonner";
+import type { User } from "@/types/api";
+import { Camera, X as XIcon, Loader2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import UserAvatar from "@/components/UserAvatar";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog'
+} from "@/components/ui/dialog";
+import { useState } from "react";
 
 interface Props {
-  user: User
-  onClose: () => void
+  user: User;
+  onClose: () => void;
+}
+
+const IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
+
+function validateImageFile(file: File): string | null {
+  if (!IMAGE_TYPES.includes(file.type))
+    return "이미지 파일만 업로드할 수 있습니다. (JPEG, PNG, WebP)";
+  if (file.size > MAX_IMAGE_SIZE) return "이미지 크기는 5MB 이하여야 합니다.";
+  return null;
 }
 
 export default function EditProfileModal({ user, onClose }: Props) {
-  const updateProfile = useUpdateProfile()
+  const updateProfile = useUpdateProfile();
+  const uploadImage = useUploadProfileImage();
 
-  const [displayName, setDisplayName] = useState(user.displayName)
-  const [bio, setBio] = useState(user.bio)
-  const [username, setUsername] = useState(user.username)
-  const [profileImageUrl, setProfileImageUrl] = useState(user.profileImageUrl)
-  const [headerImageUrl, setHeaderImageUrl] = useState(user.headerImageUrl)
+  const [displayName, setDisplayName] = useState(user.displayName);
+  const [bio, setBio] = useState(user.bio);
+  const [username, setUsername] = useState(user.username);
+  const [profileImageUrl, setProfileImageUrl] = useState(user.profileImageUrl);
+  const [headerImageUrl, setHeaderImageUrl] = useState(user.headerImageUrl);
+
+  const profileInputRef = useRef<HTMLInputElement>(null);
+  const headerInputRef = useRef<HTMLInputElement>(null);
+
+  function handleFileSelect(file: File, setUrl: (url: string) => void) {
+    const error = validateImageFile(file);
+    if (error) {
+      toast.error(error);
+      return;
+    }
+    uploadImage.mutate(file, {
+      onSuccess: (url) => setUrl(url),
+      onError: (err) =>
+        toast.error(err instanceof Error ? err.message : "업로드 실패"),
+    });
+  }
 
   function handleSave(e: React.FormEvent) {
-    e.preventDefault()
+    e.preventDefault();
     updateProfile.mutate(
       { displayName, bio, username, profileImageUrl, headerImageUrl },
       {
         onSuccess: () => {
-          toast.success('프로필이 수정되었습니다.')
-          onClose()
+          toast.success("프로필이 수정되었습니다.");
+          onClose();
         },
         onError: (err) => {
-          toast.error('프로필 수정에 실패했습니다.', { description: err.message })
+          toast.error("프로필 수정에 실패했습니다.", {
+            description: err.message,
+          });
         },
       },
-    )
+    );
   }
 
+  const isUploading = uploadImage.isPending;
+
   return (
-    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
-      <DialogContent className="max-w-[600px] p-0">
-        <DialogHeader className="flex-row items-center justify-between border-b border-border px-4 py-3">
-          <DialogTitle className="text-xl">프로필 수정</DialogTitle>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="max-w-[600px] p-0 [&>button:last-child]:hidden">
+        <DialogHeader className="flex-row items-center gap-3 border-b border-border px-4 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="cursor-pointer rounded-full border-none bg-transparent p-1 text-foreground transition-colors hover:bg-foreground/10"
+          >
+            <XIcon className="h-5 w-5" />
+          </button>
+          <DialogTitle className="flex-1 text-xl">프로필 수정</DialogTitle>
           <Button
+            type="button"
             onClick={handleSave}
             className="rounded-full"
             size="sm"
-            disabled={updateProfile.isPending}
+            disabled={updateProfile.isPending || isUploading}
           >
-            {updateProfile.isPending ? '저장 중...' : '저장'}
+            {updateProfile.isPending ? "저장 중..." : "저장"}
           </Button>
         </DialogHeader>
 
         {updateProfile.error && (
-          <p className="px-4 text-[13px] text-destructive">{updateProfile.error.message}</p>
+          <p className="px-4 text-[13px] text-destructive">
+            {updateProfile.error.message}
+          </p>
         )}
 
-        <form onSubmit={handleSave} className="flex flex-col gap-4 p-4">
+        {/* Header Image Upload */}
+        <div className="relative">
+          <input
+            ref={headerInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleFileSelect(file, setHeaderImageUrl);
+              e.target.value = "";
+            }}
+          />
+          <div
+            className="relative h-[130px] w-full cursor-pointer"
+            onClick={() => headerInputRef.current?.click()}
+          >
+            {headerImageUrl ? (
+              <img
+                src={headerImageUrl}
+                alt="헤더"
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <div className="h-full w-full bg-muted-foreground/20" />
+            )}
+            <div
+              className={`absolute inset-0 flex items-center justify-center transition-opacity ${
+                isUploading
+                  ? "bg-black/40 opacity-100"
+                  : "bg-black/30 opacity-0 hover:opacity-100"
+              }`}
+            >
+              {isUploading ? (
+                <Loader2 className="h-8 w-8 animate-spin text-white" />
+              ) : (
+                <Camera className="h-8 w-8 text-white" />
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Profile Image Upload */}
+        <div className="-mt-10 px-4">
+          <input
+            ref={profileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleFileSelect(file, setProfileImageUrl);
+              e.target.value = "";
+            }}
+          />
+          <div
+            className="relative inline-block cursor-pointer"
+            onClick={() => profileInputRef.current?.click()}
+          >
+            <UserAvatar
+              profileImageUrl={profileImageUrl}
+              displayName={displayName}
+              size="xl"
+              className="border-4 border-background"
+            />
+            <div
+              className={`absolute inset-0 flex items-center justify-center rounded-full transition-opacity ${
+                isUploading
+                  ? "bg-black/40 opacity-100"
+                  : "bg-black/30 opacity-0 hover:opacity-100"
+              }`}
+            >
+              {isUploading ? (
+                <Loader2 className="h-6 w-6 animate-spin text-white" />
+              ) : (
+                <Camera className="h-6 w-6 text-white" />
+              )}
+            </div>
+          </div>
+        </div>
+
+        <form className="flex flex-col gap-4 p-4 pt-2">
           <div className="flex flex-col gap-2">
             <Label htmlFor="displayName">이름</Label>
             <Input
@@ -90,32 +220,11 @@ export default function EditProfileModal({ user, onClose }: Props) {
               id="username"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-            />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="profileImageUrl">프로필 이미지 URL</Label>
-            <Input
-              id="profileImageUrl"
-              type="url"
-              value={profileImageUrl}
-              onChange={(e) => setProfileImageUrl(e.target.value)}
-              placeholder="https://example.com/avatar.jpg"
-            />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="headerImageUrl">헤더 이미지 URL</Label>
-            <Input
-              id="headerImageUrl"
-              type="url"
-              value={headerImageUrl}
-              onChange={(e) => setHeaderImageUrl(e.target.value)}
-              placeholder="https://example.com/header.jpg"
+              maxLength={30}
             />
           </div>
         </form>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -32,6 +32,26 @@ export function useProfile(handle: string, enabled: boolean = true) {
   })
 }
 
+async function postUploadImage(file: File): Promise<string> {
+  const formData = new FormData()
+  formData.append('file', file)
+  const res = await apiFetch('/api/media/upload', {
+    method: 'POST',
+    body: formData,
+  })
+  const json: APIResponse<{ url: string }> = await res.json()
+  if (!json.success) {
+    throw new Error(json.error ?? '이미지 업로드에 실패했습니다.')
+  }
+  return json.data.url
+}
+
+export function useUploadProfileImage() {
+  return useMutation({
+    mutationFn: postUploadImage,
+  })
+}
+
 export function useUpdateProfile() {
   const queryClient = useQueryClient()
   return useMutation({


### PR DESCRIPTION
## 📄 개요

프로필 수정 모달에서 두 가지 문제를 개선합니다:

1. **이미지 삽입 방식 변경**: URL 텍스트 입력 → 직접 파일 업로드 (클릭하여 파일 선택)
2. **버튼 겹침 수정**: DialogContent 기본 닫기(X) 버튼과 저장 버튼이 우측 상단에서 겹치는 문제 해결
3. **코드 품질**: `useUploadProfileImage` 커스텀 훅 분리 (useMutation + apiFetch)

Closes #51

<br>

## 🔨 해야 할 일

- [ ] 프로필 수정 모달 열기 → 닫기(X) 버튼과 저장 버튼이 겹치지 않는지 확인
- [ ] 헤더 이미지 영역 클릭 → 파일 선택 → 업로드 성공 확인
- [ ] 프로필 아바타 클릭 → 파일 선택 → 업로드 성공 확인
- [ ] 업로드 중 로딩 스피너 표시 확인
- [ ] 이미지 업로드 후 저장 → 프로필 반영 확인
- [ ] 5MB 초과 파일 → 에러 토스트 확인

<br>

## 🙋🏻 덧붙일 말

| 파일 | 변경 |
|------|------|
| `EditProfileModal.tsx` | 파일 업로드 UI, 버튼 레이아웃 수정 |
| `useProfile.ts` | `useUploadProfileImage` 훅 추가 |
| `docs/` | 스펙, TODO, CONTEXT, 보고서 |

- 백엔드 변경 없음 (기존 `/api/media/upload` API 재활용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)