### PR TITLE
feat: implement repost (retweet) functionality (#8)

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -78,14 +78,22 @@ type PostDetailResponse struct {
 	LikeCount    int                  `json:"likeCount"`
 	ReplyCount   int                  `json:"replyCount"`
 	ViewCount    int                  `json:"viewCount"`
+	RepostCount  int                  `json:"repostCount"`
 	IsLiked      bool                 `json:"isLiked"`
 	IsBookmarked bool                 `json:"isBookmarked"`
+	IsReposted   bool                 `json:"isReposted"`
+	RepostedBy   *RepostedBy          `json:"repostedBy,omitempty"`
 	Location     *LocationResponse    `json:"location,omitempty"`
 	Poll         *PollResponse        `json:"poll,omitempty"`
 	Media        []MediaResponse      `json:"media,omitempty"`
 	TopReplies   []PostDetailResponse `json:"topReplies"`
 	CreatedAt    string               `json:"createdAt"`
 	UpdatedAt    string               `json:"updatedAt"`
+}
+
+type RepostedBy struct {
+	Username    string `json:"username"`
+	DisplayName string `json:"displayName"`
 }
 
 type UpdatePostRequest struct {
@@ -141,10 +149,19 @@ func ToPostDetailResponse(p model.PostWithAuthor) PostDetailResponse {
 		LikeCount:    p.LikeCount,
 		ReplyCount:   p.ReplyCount,
 		ViewCount:    p.ViewCount,
+		RepostCount:  p.RepostCount,
 		IsLiked:      p.IsLiked,
 		IsBookmarked: p.IsBookmarked,
+		IsReposted:   p.IsReposted,
 		CreatedAt:    p.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		UpdatedAt:    p.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+	}
+
+	if p.RepostedByUsername != nil {
+		resp.RepostedBy = &RepostedBy{
+			Username:    *p.RepostedByUsername,
+			DisplayName: derefStr(p.RepostedByDisplayName),
+		}
 	}
 
 	if p.LocationLat != nil && p.LocationLng != nil {

--- a/backend/internal/dto/repost_dto.go
+++ b/backend/internal/dto/repost_dto.go
@@ -1,0 +1,5 @@
+package dto
+
+type RepostStatusResponse struct {
+	Reposted bool `json:"reposted"`
+}

--- a/backend/internal/handler/module.go
+++ b/backend/internal/handler/module.go
@@ -12,5 +12,6 @@ var Module = fx.Module("handler",
 		NewUserHandler,
 		NewMediaHandler,
 		NewPollHandler,
+		NewRepostHandler,
 	),
 )

--- a/backend/internal/handler/repost_handler.go
+++ b/backend/internal/handler/repost_handler.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/service"
+)
+
+type RepostHandler struct {
+	repostService service.RepostService
+}
+
+func NewRepostHandler(rs service.RepostService) *RepostHandler {
+	return &RepostHandler{repostService: rs}
+}
+
+func (h *RepostHandler) Repost(c *fiber.Ctx) error {
+	userIDStr, ok := c.Locals("userID").(string)
+	if !ok {
+		return respondError(c, apperror.Unauthorized("not authenticated"))
+	}
+
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return respondError(c, apperror.Unauthorized("invalid user ID"))
+	}
+
+	postID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return respondError(c, apperror.BadRequest("invalid post ID"))
+	}
+
+	resp, err := h.repostService.Repost(c.Context(), userID, postID)
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    resp,
+	})
+}
+
+func (h *RepostHandler) Unrepost(c *fiber.Ctx) error {
+	userIDStr, ok := c.Locals("userID").(string)
+	if !ok {
+		return respondError(c, apperror.Unauthorized("not authenticated"))
+	}
+
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return respondError(c, apperror.Unauthorized("invalid user ID"))
+	}
+
+	postID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return respondError(c, apperror.BadRequest("invalid post ID"))
+	}
+
+	resp, err := h.repostService.Unrepost(c.Context(), userID, postID)
+	if err != nil {
+		return respondError(c, err)
+	}
+
+	return c.JSON(dto.APIResponse{
+		Success: true,
+		Data:    resp,
+	})
+}

--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -23,6 +23,7 @@ type Post struct {
 	LikeCount    int
 	ReplyCount   int
 	ViewCount    int
+	RepostCount  int
 	LocationLat  *float64
 	LocationLng  *float64
 	LocationName *string
@@ -38,6 +39,10 @@ type PostWithAuthor struct {
 	AuthorProfileImageURL string
 	IsLiked               bool
 	IsBookmarked          bool
+	IsReposted            bool
+	RepostedByUsername    *string
+	RepostedByDisplayName *string
+	RepostedAt            *time.Time
 	LocationLat           *float64
 	LocationLng           *float64
 	LocationName          *string

--- a/backend/internal/repository/module.go
+++ b/backend/internal/repository/module.go
@@ -11,5 +11,6 @@ var Module = fx.Module("repository",
 		NewBookmarkRepository,
 		NewMediaRepository,
 		NewPollRepository,
+		NewRepostRepository,
 	),
 )

--- a/backend/internal/repository/post_repository.go
+++ b/backend/internal/repository/post_repository.go
@@ -57,7 +57,7 @@ func (r *postRepository) Create(ctx context.Context, post *model.Post) error {
 func (r *postRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.PostWithAuthor, error) {
 	p := &model.PostWithAuthor{}
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url,
 		       p.location_lat, p.location_lng, p.location_name
 		FROM posts p
@@ -66,7 +66,7 @@ func (r *postRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.Pos
 
 	var visibility string
 	err := r.pool.QueryRow(ctx, query, id).Scan(
-		&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.CreatedAt, &p.UpdatedAt,
+		&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
 		&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
 		&p.LocationLat, &p.LocationLng, &p.LocationName,
 	)
@@ -79,15 +79,41 @@ func (r *postRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.Pos
 
 func (r *postRepository) FindAll(ctx context.Context, limit, offset int) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
-		       u.username, u.display_name, u.profile_image_url,
-		       p.location_lat, p.location_lng, p.location_name
-		FROM posts p
-		JOIN users u ON p.author_id = u.id
-		WHERE p.parent_id IS NULL
-		  AND p.visibility = 'public'
-		  AND p.deleted_at IS NULL
-		ORDER BY p.created_at DESC
+		SELECT id, author_id, parent_id, content, visibility, like_count, reply_count, view_count, repost_count, created_at, updated_at,
+		       username, display_name, profile_image_url,
+		       location_lat, location_lng, location_name,
+		       reposted_by_username, reposted_by_display_name, reposted_at
+		FROM (
+		  SELECT DISTINCT ON (id) id, author_id, parent_id, content, visibility, like_count, reply_count, view_count, repost_count, created_at, updated_at,
+		         username, display_name, profile_image_url,
+		         location_lat, location_lng, location_name,
+		         reposted_by_username, reposted_by_display_name, reposted_at, sort_time
+		  FROM (
+		    SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
+		           u.username, u.display_name, u.profile_image_url,
+		           p.location_lat, p.location_lng, p.location_name,
+		           NULL::TEXT AS reposted_by_username, NULL::TEXT AS reposted_by_display_name, NULL::TIMESTAMPTZ AS reposted_at,
+		           p.created_at AS sort_time
+		    FROM posts p
+		    JOIN users u ON p.author_id = u.id
+		    WHERE p.parent_id IS NULL AND p.visibility = 'public' AND p.deleted_at IS NULL
+
+		    UNION ALL
+
+		    SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
+		           u.username, u.display_name, u.profile_image_url,
+		           p.location_lat, p.location_lng, p.location_name,
+		           ru.username AS reposted_by_username, ru.display_name AS reposted_by_display_name, rp.created_at AS reposted_at,
+		           rp.created_at AS sort_time
+		    FROM reposts rp
+		    JOIN posts p ON p.id = rp.post_id
+		    JOIN users u ON p.author_id = u.id
+		    JOIN users ru ON rp.user_id = ru.id
+		    WHERE p.parent_id IS NULL AND p.visibility = 'public' AND p.deleted_at IS NULL
+		  ) sub
+		  ORDER BY id, sort_time DESC
+		) deduped
+		ORDER BY sort_time DESC
 		LIMIT $1 OFFSET $2`
 
 	rows, err := r.pool.Query(ctx, query, limit, offset)
@@ -101,9 +127,10 @@ func (r *postRepository) FindAll(ctx context.Context, limit, offset int) ([]mode
 		var p model.PostWithAuthor
 		var visibility string
 		if err := rows.Scan(
-			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
 			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
 			&p.LocationLat, &p.LocationLng, &p.LocationName,
+			&p.RepostedByUsername, &p.RepostedByDisplayName, &p.RepostedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -116,10 +143,11 @@ func (r *postRepository) FindAll(ctx context.Context, limit, offset int) ([]mode
 func (r *postRepository) FindByIDWithUser(ctx context.Context, id, userID uuid.UUID) (*model.PostWithAuthor, error) {
 	p := &model.PostWithAuthor{}
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url,
 		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $2 AND l.post_id = p.id) AS is_liked,
 		       EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $2 AND b.post_id = p.id) AS is_bookmarked,
+		       EXISTS(SELECT 1 FROM reposts r WHERE r.user_id = $2 AND r.post_id = p.id) AS is_reposted,
 		       p.location_lat, p.location_lng, p.location_name
 		FROM posts p
 		JOIN users u ON p.author_id = u.id
@@ -127,9 +155,9 @@ func (r *postRepository) FindByIDWithUser(ctx context.Context, id, userID uuid.U
 
 	var visibility string
 	err := r.pool.QueryRow(ctx, query, id, userID).Scan(
-		&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.CreatedAt, &p.UpdatedAt,
+		&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
 		&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
-		&p.IsLiked, &p.IsBookmarked,
+		&p.IsLiked, &p.IsBookmarked, &p.IsReposted,
 		&p.LocationLat, &p.LocationLng, &p.LocationName,
 	)
 	if err != nil {
@@ -141,24 +169,66 @@ func (r *postRepository) FindByIDWithUser(ctx context.Context, id, userID uuid.U
 
 func (r *postRepository) FindAllWithUser(ctx context.Context, limit, offset int, userID uuid.UUID) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
-		       u.username, u.display_name, u.profile_image_url,
-		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $3 AND l.post_id = p.id) AS is_liked,
-		       EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $3 AND b.post_id = p.id) AS is_bookmarked,
-		       p.location_lat, p.location_lng, p.location_name
-		FROM posts p
-		JOIN users u ON p.author_id = u.id
-		WHERE p.parent_id IS NULL
-		  AND (
-		    p.visibility = 'public'
-		    OR (p.visibility = 'follower' AND (
-		      p.author_id = $3
-		      OR EXISTS (SELECT 1 FROM follows f WHERE f.follower_id = $3 AND f.following_id = p.author_id)
-		    ))
-		    OR (p.visibility = 'private' AND p.author_id = $3)
-		  )
-		  AND p.deleted_at IS NULL
-		ORDER BY p.created_at DESC
+		SELECT id, author_id, parent_id, content, visibility, like_count, reply_count, view_count, repost_count, created_at, updated_at,
+		       username, display_name, profile_image_url,
+		       is_liked, is_bookmarked, is_reposted,
+		       location_lat, location_lng, location_name,
+		       reposted_by_username, reposted_by_display_name, reposted_at
+		FROM (
+		  SELECT DISTINCT ON (id) id, author_id, parent_id, content, visibility, like_count, reply_count, view_count, repost_count, created_at, updated_at,
+		         username, display_name, profile_image_url,
+		         is_liked, is_bookmarked, is_reposted,
+		         location_lat, location_lng, location_name,
+		         reposted_by_username, reposted_by_display_name, reposted_at, sort_time
+		  FROM (
+		    SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
+		           u.username, u.display_name, u.profile_image_url,
+		           EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $3 AND l.post_id = p.id) AS is_liked,
+		           EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $3 AND b.post_id = p.id) AS is_bookmarked,
+		           EXISTS(SELECT 1 FROM reposts r WHERE r.user_id = $3 AND r.post_id = p.id) AS is_reposted,
+		           p.location_lat, p.location_lng, p.location_name,
+		           NULL::TEXT AS reposted_by_username, NULL::TEXT AS reposted_by_display_name, NULL::TIMESTAMPTZ AS reposted_at,
+		           p.created_at AS sort_time
+		    FROM posts p
+		    JOIN users u ON p.author_id = u.id
+		    WHERE p.parent_id IS NULL
+		      AND (
+		        p.visibility = 'public'
+		        OR (p.visibility = 'follower' AND (
+		          p.author_id = $3
+		          OR EXISTS (SELECT 1 FROM follows f WHERE f.follower_id = $3 AND f.following_id = p.author_id)
+		        ))
+		        OR (p.visibility = 'private' AND p.author_id = $3)
+		      )
+		      AND p.deleted_at IS NULL
+
+		    UNION ALL
+
+		    SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
+		           u.username, u.display_name, u.profile_image_url,
+		           EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $3 AND l.post_id = p.id) AS is_liked,
+		           EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $3 AND b.post_id = p.id) AS is_bookmarked,
+		           EXISTS(SELECT 1 FROM reposts r WHERE r.user_id = $3 AND r.post_id = p.id) AS is_reposted,
+		           p.location_lat, p.location_lng, p.location_name,
+		           ru.username AS reposted_by_username, ru.display_name AS reposted_by_display_name, rp.created_at AS reposted_at,
+		           rp.created_at AS sort_time
+		    FROM reposts rp
+		    JOIN posts p ON p.id = rp.post_id
+		    JOIN users u ON p.author_id = u.id
+		    JOIN users ru ON rp.user_id = ru.id
+		    WHERE p.parent_id IS NULL AND p.deleted_at IS NULL
+		      AND (
+		        p.visibility = 'public'
+		        OR (p.visibility = 'follower' AND (
+		          p.author_id = $3
+		          OR EXISTS (SELECT 1 FROM follows f WHERE f.follower_id = $3 AND f.following_id = p.author_id)
+		        ))
+		        OR (p.visibility = 'private' AND p.author_id = $3)
+		      )
+		  ) sub
+		  ORDER BY id, sort_time DESC
+		) deduped
+		ORDER BY sort_time DESC
 		LIMIT $1 OFFSET $2`
 
 	rows, err := r.pool.Query(ctx, query, limit, offset, userID)
@@ -172,10 +242,11 @@ func (r *postRepository) FindAllWithUser(ctx context.Context, limit, offset int,
 		var p model.PostWithAuthor
 		var visibility string
 		if err := rows.Scan(
-			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
 			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
-			&p.IsLiked, &p.IsBookmarked,
+			&p.IsLiked, &p.IsBookmarked, &p.IsReposted,
 			&p.LocationLat, &p.LocationLng, &p.LocationName,
+			&p.RepostedByUsername, &p.RepostedByDisplayName, &p.RepostedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -218,7 +289,7 @@ func (r *postRepository) CreateReply(ctx context.Context, post *model.Post) erro
 
 func (r *postRepository) FindRepliesByPostID(ctx context.Context, postID uuid.UUID, limit, offset int) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url,
 		       p.location_lat, p.location_lng, p.location_name
 		FROM posts p
@@ -239,7 +310,7 @@ func (r *postRepository) FindRepliesByPostID(ctx context.Context, postID uuid.UU
 		var p model.PostWithAuthor
 		var visibility string
 		if err := rows.Scan(
-			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
 			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
 			&p.LocationLat, &p.LocationLng, &p.LocationName,
 		); err != nil {
@@ -254,7 +325,7 @@ func (r *postRepository) FindRepliesByPostID(ctx context.Context, postID uuid.UU
 func (r *postRepository) FindAuthorReplyByPostID(ctx context.Context, postID, authorID uuid.UUID) (*model.PostWithAuthor, error) {
 	p := &model.PostWithAuthor{}
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url,
 		       p.location_lat, p.location_lng, p.location_name
 		FROM posts p
@@ -266,7 +337,7 @@ func (r *postRepository) FindAuthorReplyByPostID(ctx context.Context, postID, au
 
 	var visibility string
 	err := r.pool.QueryRow(ctx, query, postID, authorID).Scan(
-		&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.CreatedAt, &p.UpdatedAt,
+		&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
 		&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
 		&p.LocationLat, &p.LocationLng, &p.LocationName,
 	)
@@ -280,10 +351,11 @@ func (r *postRepository) FindAuthorReplyByPostID(ctx context.Context, postID, au
 func (r *postRepository) FindAuthorReplyByPostIDWithUser(ctx context.Context, postID, authorID, userID uuid.UUID) (*model.PostWithAuthor, error) {
 	p := &model.PostWithAuthor{}
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url,
 		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $3 AND l.post_id = p.id) AS is_liked,
 		       EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $3 AND b.post_id = p.id) AS is_bookmarked,
+		       EXISTS(SELECT 1 FROM reposts r WHERE r.user_id = $3 AND r.post_id = p.id) AS is_reposted,
 		       p.location_lat, p.location_lng, p.location_name
 		FROM posts p
 		JOIN users u ON p.author_id = u.id
@@ -294,9 +366,9 @@ func (r *postRepository) FindAuthorReplyByPostIDWithUser(ctx context.Context, po
 
 	var visibility string
 	err := r.pool.QueryRow(ctx, query, postID, authorID, userID).Scan(
-		&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.CreatedAt, &p.UpdatedAt,
+		&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
 		&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
-		&p.IsLiked, &p.IsBookmarked,
+		&p.IsLiked, &p.IsBookmarked, &p.IsReposted,
 		&p.LocationLat, &p.LocationLng, &p.LocationName,
 	)
 	if err != nil {
@@ -308,10 +380,11 @@ func (r *postRepository) FindAuthorReplyByPostIDWithUser(ctx context.Context, po
 
 func (r *postRepository) FindRepliesByPostIDWithUser(ctx context.Context, postID, userID uuid.UUID, limit, offset int) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url,
 		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $3 AND l.post_id = p.id) AS is_liked,
 		       EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $3 AND b.post_id = p.id) AS is_bookmarked,
+		       EXISTS(SELECT 1 FROM reposts r WHERE r.user_id = $3 AND r.post_id = p.id) AS is_reposted,
 		       p.location_lat, p.location_lng, p.location_name
 		FROM posts p
 		JOIN users u ON p.author_id = u.id
@@ -331,9 +404,9 @@ func (r *postRepository) FindRepliesByPostIDWithUser(ctx context.Context, postID
 		var p model.PostWithAuthor
 		var visibility string
 		if err := rows.Scan(
-			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
 			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
-			&p.IsLiked, &p.IsBookmarked,
+			&p.IsLiked, &p.IsBookmarked, &p.IsReposted,
 			&p.LocationLat, &p.LocationLng, &p.LocationName,
 		); err != nil {
 			return nil, err
@@ -359,11 +432,11 @@ func (r *postRepository) scanPostRows(rows scannable, withIsLiked bool) ([]model
 		var visibility string
 		var scanArgs []any
 		scanArgs = append(scanArgs,
-			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
 			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
 		)
 		if withIsLiked {
-			scanArgs = append(scanArgs, &p.IsLiked, &p.IsBookmarked)
+			scanArgs = append(scanArgs, &p.IsLiked, &p.IsBookmarked, &p.IsReposted)
 		}
 		scanArgs = append(scanArgs, &p.LocationLat, &p.LocationLng, &p.LocationName)
 		if err := rows.Scan(scanArgs...); err != nil {
@@ -377,49 +450,155 @@ func (r *postRepository) scanPostRows(rows scannable, withIsLiked bool) ([]model
 
 func (r *postRepository) FindByAuthorHandle(ctx context.Context, handle string, limit, offset int) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
-		       u.username, u.display_name, u.profile_image_url,
-		       p.location_lat, p.location_lng, p.location_name
-		FROM posts p
-		JOIN users u ON p.author_id = u.id
-		WHERE u.username = $1 AND p.parent_id IS NULL
-		  AND p.visibility = 'public' AND p.deleted_at IS NULL
-		ORDER BY p.created_at DESC
+		SELECT id, author_id, parent_id, content, visibility, like_count, reply_count, view_count, repost_count, created_at, updated_at,
+		       username, display_name, profile_image_url,
+		       location_lat, location_lng, location_name,
+		       reposted_by_username, reposted_by_display_name, reposted_at
+		FROM (
+		  SELECT DISTINCT ON (id) id, author_id, parent_id, content, visibility, like_count, reply_count, view_count, repost_count, created_at, updated_at,
+		         username, display_name, profile_image_url,
+		         location_lat, location_lng, location_name,
+		         reposted_by_username, reposted_by_display_name, reposted_at, sort_time
+		  FROM (
+		    SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
+		           u.username, u.display_name, u.profile_image_url,
+		           p.location_lat, p.location_lng, p.location_name,
+		           NULL::TEXT AS reposted_by_username, NULL::TEXT AS reposted_by_display_name, NULL::TIMESTAMPTZ AS reposted_at,
+		           p.created_at AS sort_time
+		    FROM posts p
+		    JOIN users u ON p.author_id = u.id
+		    WHERE u.username = $1 AND p.parent_id IS NULL
+		      AND p.visibility = 'public' AND p.deleted_at IS NULL
+
+		    UNION ALL
+
+		    SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
+		           u.username, u.display_name, u.profile_image_url,
+		           p.location_lat, p.location_lng, p.location_name,
+		           ru.username AS reposted_by_username, ru.display_name AS reposted_by_display_name, rp.created_at AS reposted_at,
+		           rp.created_at AS sort_time
+		    FROM reposts rp
+		    JOIN users ru ON rp.user_id = ru.id
+		    JOIN posts p ON p.id = rp.post_id
+		    JOIN users u ON p.author_id = u.id
+		    WHERE ru.username = $1 AND p.parent_id IS NULL
+		      AND p.visibility = 'public' AND p.deleted_at IS NULL
+		  ) sub
+		  ORDER BY id, sort_time DESC
+		) deduped
+		ORDER BY sort_time DESC
 		LIMIT $2 OFFSET $3`
 
 	rows, err := r.pool.Query(ctx, query, handle, limit, offset)
 	if err != nil {
 		return nil, err
 	}
-	return r.scanPostRows(rows, false)
+	defer rows.Close()
+
+	var posts []model.PostWithAuthor
+	for rows.Next() {
+		var p model.PostWithAuthor
+		var visibility string
+		if err := rows.Scan(
+			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
+			&p.LocationLat, &p.LocationLng, &p.LocationName,
+			&p.RepostedByUsername, &p.RepostedByDisplayName, &p.RepostedAt,
+		); err != nil {
+			return nil, err
+		}
+		p.Visibility = model.Visibility(visibility)
+		posts = append(posts, p)
+	}
+	return posts, rows.Err()
 }
 
 func (r *postRepository) FindByAuthorHandleWithUser(ctx context.Context, handle string, limit, offset int, userID uuid.UUID) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
-		       u.username, u.display_name, u.profile_image_url,
-		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $4 AND l.post_id = p.id) AS is_liked,
-		       EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $4 AND b.post_id = p.id) AS is_bookmarked,
-		       p.location_lat, p.location_lng, p.location_name
-		FROM posts p
-		JOIN users u ON p.author_id = u.id
-		WHERE u.username = $1 AND p.parent_id IS NULL AND p.deleted_at IS NULL
-		  AND (
-		    p.visibility = 'public'
-		    OR (p.visibility = 'follower' AND (
-		      p.author_id = $4
-		      OR EXISTS (SELECT 1 FROM follows f WHERE f.follower_id = $4 AND f.following_id = p.author_id)
-		    ))
-		    OR (p.visibility = 'private' AND p.author_id = $4)
-		  )
-		ORDER BY p.created_at DESC
+		SELECT id, author_id, parent_id, content, visibility, like_count, reply_count, view_count, repost_count, created_at, updated_at,
+		       username, display_name, profile_image_url,
+		       is_liked, is_bookmarked, is_reposted,
+		       location_lat, location_lng, location_name,
+		       reposted_by_username, reposted_by_display_name, reposted_at
+		FROM (
+		  SELECT DISTINCT ON (id) id, author_id, parent_id, content, visibility, like_count, reply_count, view_count, repost_count, created_at, updated_at,
+		         username, display_name, profile_image_url,
+		         is_liked, is_bookmarked, is_reposted,
+		         location_lat, location_lng, location_name,
+		         reposted_by_username, reposted_by_display_name, reposted_at, sort_time
+		  FROM (
+		    SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
+		           u.username, u.display_name, u.profile_image_url,
+		           EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $4 AND l.post_id = p.id) AS is_liked,
+		           EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $4 AND b.post_id = p.id) AS is_bookmarked,
+		           EXISTS(SELECT 1 FROM reposts r WHERE r.user_id = $4 AND r.post_id = p.id) AS is_reposted,
+		           p.location_lat, p.location_lng, p.location_name,
+		           NULL::TEXT AS reposted_by_username, NULL::TEXT AS reposted_by_display_name, NULL::TIMESTAMPTZ AS reposted_at,
+		           p.created_at AS sort_time
+		    FROM posts p
+		    JOIN users u ON p.author_id = u.id
+		    WHERE u.username = $1 AND p.parent_id IS NULL AND p.deleted_at IS NULL
+		      AND (
+		        p.visibility = 'public'
+		        OR (p.visibility = 'follower' AND (
+		          p.author_id = $4
+		          OR EXISTS (SELECT 1 FROM follows f WHERE f.follower_id = $4 AND f.following_id = p.author_id)
+		        ))
+		        OR (p.visibility = 'private' AND p.author_id = $4)
+		      )
+
+		    UNION ALL
+
+		    SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
+		           u.username, u.display_name, u.profile_image_url,
+		           EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $4 AND l.post_id = p.id) AS is_liked,
+		           EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $4 AND b.post_id = p.id) AS is_bookmarked,
+		           EXISTS(SELECT 1 FROM reposts r WHERE r.user_id = $4 AND r.post_id = p.id) AS is_reposted,
+		           p.location_lat, p.location_lng, p.location_name,
+		           ru.username AS reposted_by_username, ru.display_name AS reposted_by_display_name, rp.created_at AS reposted_at,
+		           rp.created_at AS sort_time
+		    FROM reposts rp
+		    JOIN users ru ON rp.user_id = ru.id
+		    JOIN posts p ON p.id = rp.post_id
+		    JOIN users u ON p.author_id = u.id
+		    WHERE ru.username = $1 AND p.parent_id IS NULL AND p.deleted_at IS NULL
+		      AND (
+		        p.visibility = 'public'
+		        OR (p.visibility = 'follower' AND (
+		          p.author_id = $4
+		          OR EXISTS (SELECT 1 FROM follows f WHERE f.follower_id = $4 AND f.following_id = p.author_id)
+		        ))
+		        OR (p.visibility = 'private' AND p.author_id = $4)
+		      )
+		  ) sub
+		  ORDER BY id, sort_time DESC
+		) deduped
+		ORDER BY sort_time DESC
 		LIMIT $2 OFFSET $3`
 
 	rows, err := r.pool.Query(ctx, query, handle, limit, offset, userID)
 	if err != nil {
 		return nil, err
 	}
-	return r.scanPostRows(rows, true)
+	defer rows.Close()
+
+	var posts []model.PostWithAuthor
+	for rows.Next() {
+		var p model.PostWithAuthor
+		var visibility string
+		if err := rows.Scan(
+			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
+			&p.IsLiked, &p.IsBookmarked, &p.IsReposted,
+			&p.LocationLat, &p.LocationLng, &p.LocationName,
+			&p.RepostedByUsername, &p.RepostedByDisplayName, &p.RepostedAt,
+		); err != nil {
+			return nil, err
+		}
+		p.Visibility = model.Visibility(visibility)
+		posts = append(posts, p)
+	}
+	return posts, rows.Err()
 }
 
 func (r *postRepository) scanReplyWithParentRows(rows scannable, withIsLiked bool) ([]model.PostWithAuthor, error) {
@@ -430,11 +609,11 @@ func (r *postRepository) scanReplyWithParentRows(rows scannable, withIsLiked boo
 		var visibility string
 		var scanArgs []any
 		scanArgs = append(scanArgs,
-			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.CreatedAt, &p.UpdatedAt,
+			&p.ID, &p.AuthorID, &p.ParentID, &p.Content, &visibility, &p.LikeCount, &p.ReplyCount, &p.ViewCount, &p.RepostCount, &p.CreatedAt, &p.UpdatedAt,
 			&p.AuthorUsername, &p.AuthorDisplayName, &p.AuthorProfileImageURL,
 		)
 		if withIsLiked {
-			scanArgs = append(scanArgs, &p.IsLiked, &p.IsBookmarked)
+			scanArgs = append(scanArgs, &p.IsLiked, &p.IsBookmarked, &p.IsReposted)
 		}
 		scanArgs = append(scanArgs, &p.LocationLat, &p.LocationLng, &p.LocationName)
 		scanArgs = append(scanArgs,
@@ -452,7 +631,7 @@ func (r *postRepository) scanReplyWithParentRows(rows scannable, withIsLiked boo
 
 func (r *postRepository) FindRepliesByAuthorHandle(ctx context.Context, handle string, limit, offset int) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url,
 		       p.location_lat, p.location_lng, p.location_name,
 		       pp.id, pp.content,
@@ -475,10 +654,11 @@ func (r *postRepository) FindRepliesByAuthorHandle(ctx context.Context, handle s
 
 func (r *postRepository) FindRepliesByAuthorHandleWithUser(ctx context.Context, handle string, limit, offset int, userID uuid.UUID) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url,
 		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $4 AND l.post_id = p.id) AS is_liked,
 		       EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $4 AND b.post_id = p.id) AS is_bookmarked,
+		       EXISTS(SELECT 1 FROM reposts r WHERE r.user_id = $4 AND r.post_id = p.id) AS is_reposted,
 		       p.location_lat, p.location_lng, p.location_name,
 		       pp.id, pp.content,
 		       pu.username, pu.display_name, pu.profile_image_url
@@ -507,7 +687,7 @@ func (r *postRepository) FindRepliesByAuthorHandleWithUser(ctx context.Context, 
 
 func (r *postRepository) FindLikedByUserHandle(ctx context.Context, handle string, limit, offset int) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url,
 		       p.location_lat, p.location_lng, p.location_name
 		FROM likes lk
@@ -528,10 +708,11 @@ func (r *postRepository) FindLikedByUserHandle(ctx context.Context, handle strin
 
 func (r *postRepository) FindLikedByUserHandleWithViewer(ctx context.Context, handle string, limit, offset int, viewerID uuid.UUID) ([]model.PostWithAuthor, error) {
 	query := `
-		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.created_at, p.updated_at,
+		SELECT p.id, p.author_id, p.parent_id, p.content, p.visibility, p.like_count, p.reply_count, p.view_count, p.repost_count, p.created_at, p.updated_at,
 		       u.username, u.display_name, u.profile_image_url,
 		       EXISTS(SELECT 1 FROM likes l WHERE l.user_id = $4 AND l.post_id = p.id) AS is_liked,
 		       EXISTS(SELECT 1 FROM bookmarks b WHERE b.user_id = $4 AND b.post_id = p.id) AS is_bookmarked,
+		       EXISTS(SELECT 1 FROM reposts r WHERE r.user_id = $4 AND r.post_id = p.id) AS is_reposted,
 		       p.location_lat, p.location_lng, p.location_name
 		FROM likes lk
 		JOIN users target ON target.username = $1

--- a/backend/internal/repository/repost_repository.go
+++ b/backend/internal/repository/repost_repository.go
@@ -1,0 +1,89 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type RepostRepository interface {
+	Repost(ctx context.Context, userID, postID uuid.UUID) error
+	Unrepost(ctx context.Context, userID, postID uuid.UUID) error
+	IsReposted(ctx context.Context, userID, postID uuid.UUID) (bool, error)
+}
+
+type repostRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewRepostRepository(pool *pgxpool.Pool) RepostRepository {
+	return &repostRepository{pool: pool}
+}
+
+func (r *repostRepository) Repost(ctx context.Context, userID, postID uuid.UUID) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = tx.Exec(ctx,
+		`INSERT INTO reposts (user_id, post_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+		userID, postID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to insert repost: %w", err)
+	}
+
+	_, err = tx.Exec(ctx,
+		`UPDATE posts SET repost_count = repost_count + 1 WHERE id = $1`,
+		postID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update repost_count: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (r *repostRepository) Unrepost(ctx context.Context, userID, postID uuid.UUID) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	tag, err := tx.Exec(ctx,
+		`DELETE FROM reposts WHERE user_id = $1 AND post_id = $2`,
+		userID, postID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to delete repost: %w", err)
+	}
+
+	if tag.RowsAffected() > 0 {
+		_, err = tx.Exec(ctx,
+			`UPDATE posts SET repost_count = GREATEST(repost_count - 1, 0) WHERE id = $1`,
+			postID,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to update repost_count: %w", err)
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (r *repostRepository) IsReposted(ctx context.Context, userID, postID uuid.UUID) (bool, error) {
+	var exists bool
+	err := r.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM reposts WHERE user_id = $1 AND post_id = $2)`,
+		userID, postID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to check repost status: %w", err)
+	}
+	return exists, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -24,6 +24,7 @@ type Params struct {
 	UserHandler     *handler.UserHandler
 	MediaHandler    *handler.MediaHandler
 	PollHandler     *handler.PollHandler
+	RepostHandler   *handler.RepostHandler
 }
 
 func Setup(p Params) {
@@ -50,6 +51,8 @@ func Setup(p Params) {
 	posts.Delete("/:id/bookmark", middleware.AuthRequired(jwtSecret), p.BookmarkHandler.Unbookmark)
 	posts.Post("/:id/vote", middleware.AuthRequired(jwtSecret), p.PollHandler.Vote)
 	posts.Delete("/:id/vote", middleware.AuthRequired(jwtSecret), p.PollHandler.Unvote)
+	posts.Post("/:id/repost", middleware.AuthRequired(jwtSecret), p.RepostHandler.Repost)
+	posts.Delete("/:id/repost", middleware.AuthRequired(jwtSecret), p.RepostHandler.Unrepost)
 
 	auth := api.Group("/auth")
 	auth.Post("/register", p.AuthHandler.Register)

--- a/backend/internal/service/module.go
+++ b/backend/internal/service/module.go
@@ -12,5 +12,6 @@ var Module = fx.Module("service",
 		NewUserService,
 		NewMediaService,
 		NewPollService,
+		NewRepostService,
 	),
 )

--- a/backend/internal/service/repost_service.go
+++ b/backend/internal/service/repost_service.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/apperror"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/dto"
+	"github.com/kitae0522/twitter-clone-claude/backend/internal/repository"
+)
+
+type RepostService interface {
+	Repost(ctx context.Context, userID, postID uuid.UUID) (*dto.RepostStatusResponse, error)
+	Unrepost(ctx context.Context, userID, postID uuid.UUID) (*dto.RepostStatusResponse, error)
+}
+
+type repostService struct {
+	repostRepo repository.RepostRepository
+	postRepo   repository.PostRepository
+}
+
+func NewRepostService(repostRepo repository.RepostRepository, postRepo repository.PostRepository) RepostService {
+	return &repostService{repostRepo: repostRepo, postRepo: postRepo}
+}
+
+func (s *repostService) Repost(ctx context.Context, userID, postID uuid.UUID) (*dto.RepostStatusResponse, error) {
+	post, err := s.postRepo.FindByID(ctx, postID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, apperror.NotFound("post not found")
+		}
+		return nil, apperror.Internal("failed to find post")
+	}
+
+	if post.AuthorID == userID {
+		return nil, apperror.BadRequest("cannot repost your own post")
+	}
+
+	reposted, err := s.repostRepo.IsReposted(ctx, userID, postID)
+	if err != nil {
+		return nil, apperror.Internal("failed to check repost status")
+	}
+	if reposted {
+		return nil, apperror.Conflict("already reposted")
+	}
+
+	if err := s.repostRepo.Repost(ctx, userID, postID); err != nil {
+		return nil, apperror.Internal("failed to repost")
+	}
+
+	return &dto.RepostStatusResponse{Reposted: true}, nil
+}
+
+func (s *repostService) Unrepost(ctx context.Context, userID, postID uuid.UUID) (*dto.RepostStatusResponse, error) {
+	_, err := s.postRepo.FindByID(ctx, postID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, apperror.NotFound("post not found")
+		}
+		return nil, apperror.Internal("failed to find post")
+	}
+
+	reposted, err := s.repostRepo.IsReposted(ctx, userID, postID)
+	if err != nil {
+		return nil, apperror.Internal("failed to check repost status")
+	}
+	if !reposted {
+		return nil, apperror.Conflict("not reposted yet")
+	}
+
+	if err := s.repostRepo.Unrepost(ctx, userID, postID); err != nil {
+		return nil, apperror.Internal("failed to unrepost")
+	}
+
+	return &dto.RepostStatusResponse{Reposted: false}, nil
+}

--- a/backend/migrations/016_create_reposts.down.sql
+++ b/backend/migrations/016_create_reposts.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE posts DROP COLUMN IF EXISTS repost_count;
+DROP TABLE IF EXISTS reposts;

--- a/backend/migrations/016_create_reposts.up.sql
+++ b/backend/migrations/016_create_reposts.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE reposts (
+  user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  post_id    UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, post_id)
+);
+CREATE INDEX idx_reposts_post_id ON reposts(post_id);
+CREATE INDEX idx_reposts_user_created ON reposts(user_id, created_at DESC);
+ALTER TABLE posts ADD COLUMN repost_count INT NOT NULL DEFAULT 0;

--- a/frontend/src/components/PostCard.tsx
+++ b/frontend/src/components/PostCard.tsx
@@ -16,6 +16,7 @@ import VisibilityBadge from "@/components/VisibilityBadge";
 import type { PostDetail } from "@/types/api";
 import { useAuth } from "@/hooks/useAuthContext";
 import { useLike } from "@/hooks/useLike";
+import { useRepost } from "@/hooks/useRepost";
 import { useBookmark } from "@/hooks/useBookmark";
 import { formatRelativeTime, formatCompactNumber } from "@/lib/formatTime";
 import ProfileHoverCard from "@/components/ProfileHoverCard";
@@ -59,12 +60,19 @@ function PostCard({ post }: PostCardProps) {
 
   const deletePost = useDeletePost(post.id);
   const like = useLike(post.id, post.isLiked);
+  const repost = useRepost(post.id, post.isReposted);
   const bookmark = useBookmark(post.id, post.isBookmarked);
 
   function handleLikeClick(e: React.MouseEvent) {
     e.stopPropagation();
     if (!currentUser) return;
     like.mutate();
+  }
+
+  function handleRepostClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (!currentUser || isOwner) return;
+    repost.mutate();
   }
 
   return (
@@ -77,6 +85,28 @@ function PostCard({ post }: PostCardProps) {
         if (e.key === "Enter") navigate(`/post/${post.id}`);
       }}
     >
+      {post.repostedBy && (
+        <div className="flex items-center gap-1.5 px-4 pb-1 text-[13px] text-muted-foreground">
+          <Repeat2 size={14} className="text-green-500" />
+          <span>
+            <ProfileHoverCard
+              handle={post.repostedBy.username}
+              currentUsername={currentUser?.username}
+            >
+              <span
+                className="cursor-pointer hover:underline"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigate(`/${post.repostedBy!.username}`);
+                }}
+              >
+                {post.repostedBy.displayName || post.repostedBy.username}
+              </span>
+            </ProfileHoverCard>
+            님이 재게시함
+          </span>
+        </div>
+      )}
       <div className="flex gap-3">
         <div
           className="mt-0.5 shrink-0 cursor-pointer"
@@ -255,13 +285,28 @@ function PostCard({ post }: PostCardProps) {
 
             {/* Repost */}
             <button
-              onClick={(e) => e.stopPropagation()}
-              className="group flex cursor-pointer items-center gap-1.5 rounded-full border-none bg-transparent p-2 transition-colors hover:bg-green-500/10"
+              onClick={handleRepostClick}
+              disabled={isOwner}
+              className={cn(
+                "group flex cursor-pointer items-center gap-1.5 rounded-full border-none bg-transparent p-2 transition-colors hover:bg-green-500/10",
+                isOwner && "cursor-not-allowed opacity-50",
+              )}
             >
               <Repeat2
                 size={18}
-                className="text-muted-foreground transition-colors group-hover:text-green-500"
+                className={cn(
+                  "transition-colors group-hover:text-green-500",
+                  post.isReposted ? "text-green-500" : "text-muted-foreground",
+                )}
               />
+              <span
+                className={cn(
+                  "text-[13px] transition-colors group-hover:text-green-500",
+                  post.isReposted ? "text-green-500" : "text-muted-foreground",
+                )}
+              >
+                {post.repostCount || ""}
+              </span>
             </button>
 
             {/* Like */}

--- a/frontend/src/hooks/useRepost.ts
+++ b/frontend/src/hooks/useRepost.ts
@@ -1,0 +1,113 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type {
+  APIResponse,
+  RepostStatusResponse,
+  PostDetail,
+} from "@/types/api";
+import { apiFetch } from "@/lib/api";
+
+async function postRepost(postId: string): Promise<RepostStatusResponse> {
+  const res = await apiFetch(`/api/posts/${postId}/repost`, { method: "POST" });
+  const json: APIResponse<RepostStatusResponse> = await res.json();
+  if (!json.success) {
+    throw new Error(json.error ?? "Failed to repost");
+  }
+  return json.data;
+}
+
+async function deleteRepost(postId: string): Promise<RepostStatusResponse> {
+  const res = await apiFetch(`/api/posts/${postId}/repost`, {
+    method: "DELETE",
+  });
+  const json: APIResponse<RepostStatusResponse> = await res.json();
+  if (!json.success) {
+    throw new Error(json.error ?? "Failed to unrepost");
+  }
+  return json.data;
+}
+
+function updatePostInCache(old: PostDetail, reposted: boolean): PostDetail {
+  return {
+    ...old,
+    isReposted: reposted,
+    repostCount: old.repostCount + (reposted ? 1 : -1),
+  };
+}
+
+export function useRepost(
+  postId: string,
+  isReposted: boolean,
+  parentId?: string,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => (isReposted ? deleteRepost(postId) : postRepost(postId)),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ["posts"] });
+      await queryClient.cancelQueries({ queryKey: ["post", postId] });
+      if (parentId) {
+        await queryClient.cancelQueries({
+          queryKey: ["post", parentId, "replies"],
+        });
+      }
+
+      const prevPosts = queryClient.getQueryData<PostDetail[]>(["posts"]);
+      const prevPost = queryClient.getQueryData<PostDetail>(["post", postId]);
+      const prevReplies = parentId
+        ? queryClient.getQueryData<PostDetail[]>(["post", parentId, "replies"])
+        : undefined;
+
+      const nextReposted = !isReposted;
+
+      if (prevPosts) {
+        queryClient.setQueryData<PostDetail[]>(["posts"], (old) =>
+          old?.map((p) =>
+            p.id === postId ? updatePostInCache(p, nextReposted) : p,
+          ),
+        );
+      }
+
+      if (prevPost) {
+        queryClient.setQueryData<PostDetail>(["post", postId], (old) =>
+          old ? updatePostInCache(old, nextReposted) : old,
+        );
+      }
+
+      if (parentId && prevReplies) {
+        queryClient.setQueryData<PostDetail[]>(
+          ["post", parentId, "replies"],
+          (old) =>
+            old?.map((r) =>
+              r.id === postId ? updatePostInCache(r, nextReposted) : r,
+            ),
+        );
+      }
+
+      return { prevPosts, prevPost, prevReplies };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.prevPosts) {
+        queryClient.setQueryData(["posts"], context.prevPosts);
+      }
+      if (context?.prevPost) {
+        queryClient.setQueryData(["post", postId], context.prevPost);
+      }
+      if (parentId && context?.prevReplies) {
+        queryClient.setQueryData(
+          ["post", parentId, "replies"],
+          context.prevReplies,
+        );
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["posts"] });
+      queryClient.invalidateQueries({ queryKey: ["post", postId] });
+      if (parentId) {
+        queryClient.invalidateQueries({
+          queryKey: ["post", parentId, "replies"],
+        });
+      }
+    },
+  });
+}

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -15,6 +15,7 @@ import {
 import { usePostDetail, useParentChain, useDeletePost } from "@/hooks/usePosts";
 import { useAuth } from "@/hooks/useAuthContext";
 import { useLike } from "@/hooks/useLike";
+import { useRepost } from "@/hooks/useRepost";
 import { useBookmark } from "@/hooks/useBookmark";
 import { formatRelativeTime, formatCompactNumber } from "@/lib/formatTime";
 import ProfileHoverCard from "@/components/ProfileHoverCard";
@@ -58,6 +59,7 @@ export default function PostDetailPage() {
   const authorUsername = post?.author.username ?? "";
   const isOwner = currentUser?.username === authorUsername;
   const like = useLike(postId, post?.isLiked ?? false);
+  const repost = useRepost(postId, post?.isReposted ?? false);
   const bookmark = useBookmark(postId, post?.isBookmarked ?? false);
   const deletePost = useDeletePost(postId);
   const { data: parentChain } = useParentChain(post?.parentId ?? null);
@@ -87,6 +89,11 @@ export default function PostDetailPage() {
   function handleLikeClick() {
     if (!currentUser) return;
     like.mutate();
+  }
+
+  function handleRepostClick() {
+    if (!currentUser || isOwner) return;
+    repost.mutate();
   }
 
   return (
@@ -240,7 +247,10 @@ export default function PostDetailPage() {
         </div>
 
         {/* Stats */}
-        {(post.likeCount > 0 || post.replyCount > 0 || post.viewCount > 0) && (
+        {(post.likeCount > 0 ||
+          post.replyCount > 0 ||
+          post.viewCount > 0 ||
+          post.repostCount > 0) && (
           <div className="mt-3 flex gap-4 border-t border-border pt-3 text-sm">
             {post.viewCount > 0 && (
               <span className="text-muted-foreground">
@@ -254,6 +264,12 @@ export default function PostDetailPage() {
               <span className="text-muted-foreground">
                 <strong className="text-foreground">{post.replyCount}</strong>{" "}
                 답글
+              </span>
+            )}
+            {post.repostCount > 0 && (
+              <span className="text-muted-foreground">
+                <strong className="text-foreground">{post.repostCount}</strong>{" "}
+                재게시
               </span>
             )}
             {post.likeCount > 0 && (
@@ -276,10 +292,20 @@ export default function PostDetailPage() {
               className="text-muted-foreground transition-colors group-hover:text-primary"
             />
           </button>
-          <button className="group flex cursor-pointer items-center justify-center rounded-full border-none bg-transparent p-2 transition-colors hover:bg-green-500/10">
+          <button
+            onClick={handleRepostClick}
+            disabled={isOwner}
+            className={cn(
+              "group flex cursor-pointer items-center justify-center rounded-full border-none bg-transparent p-2 transition-colors hover:bg-green-500/10",
+              isOwner && "cursor-not-allowed opacity-50",
+            )}
+          >
             <Repeat2
               size={20}
-              className="text-muted-foreground transition-colors group-hover:text-green-500"
+              className={cn(
+                "transition-colors group-hover:text-green-500",
+                post.isReposted ? "text-green-500" : "text-muted-foreground",
+              )}
             />
           </button>
           <button

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -144,8 +144,11 @@ export interface PostDetail {
   likeCount: number;
   replyCount: number;
   viewCount: number;
+  repostCount: number;
   isLiked: boolean;
   isBookmarked: boolean;
+  isReposted: boolean;
+  repostedBy?: { username: string; displayName: string } | null;
   media?: MediaItem[] | null;
   location?: LocationData | null;
   poll?: PollData | null;
@@ -187,6 +190,10 @@ export interface CreateReplyRequest {
 
 export interface LikeStatusResponse {
   liked: boolean;
+}
+
+export interface RepostStatusResponse {
+  reposted: boolean;
 }
 
 export interface BookmarkStatusResponse {


### PR DESCRIPTION
## 📄 개요

> 사용자가 다른 사람의 글을 자신의 타임라인으로 퍼뜨리는 Repost(재게시) 기능을 구현합니다.
> 기존 likes/bookmarks 패턴을 따라 별도 `reposts` 테이블 사용, 원본 데이터를 복사하지 않고 참조 방식으로 중복 방지합니다.

<br>

## 🔨 해야 할 일

- [x] DB 마이그레이션 (`reposts` 테이블 + `posts.repost_count` 컬럼)
- [x] Backend Repository / Service / Handler / Router 구현
- [x] 셀프 리포스트 차단 (서비스 레이어)
- [x] 모든 post 쿼리에 `repost_count`, `is_reposted` 필드 추가
- [x] 피드 및 프로필 페이지에 리포스트된 글 UNION ALL 포함
- [x] DISTINCT ON 으로 피드 중복 제거
- [x] Frontend `useRepost` 훅 (낙관적 업데이트)
- [x] PostCard / PostDetailPage에 리포스트 버튼 + 카운트 + 라벨 표시
- [x] "ㅇㅇ님이 재게시함" 라벨 클릭 시 프로필 이동 + ProfileHoverCard 적용

<br>

## 🙋🏻 덧붙일 말

- `go build ./...`, `go test ./...`, `bun run check` 모두 통과 확인
- 자기 글 리포스트 시 버튼 비활성화 + 서버 400 에러 반환
- 17개 파일 변경 (신규 7개 + 수정 10개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)