### PR TITLE
chore: add allowedHosts for Cloudflare Tunnel support

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   },
   server: {
     host: true,
+    allowedHosts: true,
     proxy: {
       "/api": {
         target: "http://backend:8080",


### PR DESCRIPTION
## Summary
- Vite dev server에 `allowedHosts: true` 설정 추가
- Cloudflare Tunnel을 통한 외부 접근 시 host header 검증 우회 지원

## Test plan
- [ ] `bun run dev`로 로컬 개발 서버 정상 기동 확인
- [ ] Cloudflare Tunnel을 통한 외부 접근 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)